### PR TITLE
Fix Crash-reporting by using "properties.TryAdd()" instead of properties.Add to avoid throwing and…

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -221,7 +221,7 @@ private const string userIdKey = nameof(userIdKey);
                 properties = new Dictionary<string, string>();
             }
 
-            properties.Add("StackTrace", ex.StackTrace);
+            properties.TryAdd("StackTrace", ex.StackTrace);
             
             client.TrackException(ex, properties);
             client.Flush();


### PR DESCRIPTION
… ArgumentException when "StackTrace" key was already added for Crashes