### PR TITLE
First initial Crash is not persisted

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -135,7 +135,7 @@ private const string userIdKey = nameof(userIdKey);
         {
             var crashes = ReadCrashes();
 
-            if (crashes != null)
+            if (crashes.Count > 0)
             {
                 Debug.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
 
@@ -150,10 +150,10 @@ private const string userIdKey = nameof(userIdKey);
                         {"Source", crash.Source}
                     };
 
-
-
                     await TrackErrorAsync(ex, properties);
                 }
+
+                ResetCrashes();
             }
         }
         catch (Exception)
@@ -189,6 +189,18 @@ private const string userIdKey = nameof(userIdKey);
         return new List<Crash>();
     }
 
+    private void ResetCrashes()
+    {
+        try
+        {
+            var path = Path.Combine(logPath, crashLogFilename);
+            File.Delete(path);
+        }
+        catch (Exception)
+        {
+        }
+    }   
+    
     private void HandleCrash(Exception ex)
     {
         try
@@ -201,13 +213,7 @@ private const string userIdKey = nameof(userIdKey);
 
             var path = Path.Combine(logPath, crashLogFilename);
 
-            if (!File.Exists(path))
-            {
-                File.Create(path);
-            }
-
             System.IO.File.WriteAllText(path, json);
-
         }
         catch (Exception)
         {

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -221,7 +221,7 @@ private const string userIdKey = nameof(userIdKey);
                 properties = new Dictionary<string, string>();
             }
 
-            properties.Add("StackTrace", ex.StackTrace);
+            properties.TryAdd("StackTrace", ex.StackTrace);
             
             client.TrackException(ex, properties);
             client.Flush();


### PR DESCRIPTION
Sorry should have seen this on my initial pull - but the initial Crash is not persisted correctly.

The code to `File.Create(path)` apparently does *not* release the file fast enough to make `WriteAllText` succeed.

It thows the exception: "The process cannot access the file '<path>/crashes.mauiinsights' because it is being used by another process." 

I removed the check to `File.Exists` and `File.Create` as `WriteAllText` itself will create any missing file.

I also implemented `ResetCrashes()` method to remove crashes from the file when they have been reported to AppInsights.