### PR TITLE
Add Escape Char for Special Char(s)

### DIFF
--- a/TinyInsights.Web/Pages/ErrorDetails.razor
+++ b/TinyInsights.Web/Pages/ErrorDetails.razor
@@ -145,14 +145,16 @@
     private async Task LoadData()
     {
         isLoading = true;
+        // Replace ' with the \'
+        var escapedId = Id.Replace("'", "\\'");
 
         if (isCrash)
         {
-            data = await Service.GetCrashDetails(Id, GlobalFilter);
+            data = await Service.GetCrashDetails(escapedId, GlobalFilter);
         }
         else
         {
-            data = await Service.GetErrorDetails(Id, GlobalFilter);
+            data = await Service.GetErrorDetails(escapedId, GlobalFilter);
         }
 
         isLoading = false;

--- a/TinyInsights.Web/Services/Models/ErrorItem.cs
+++ b/TinyInsights.Web/Services/Models/ErrorItem.cs
@@ -12,7 +12,7 @@ public class ErrorItem : LogItem
     public string? ClientType => GetData("client_Type");
     public string? ClientModel => GetData("client_Model");
     public string? ClientOs => GetData("client_OS");
-    public string? ClientOsVersion => GetData("OperatingSystemVersion");
+    public string? ClientOsVersion => GetData("OperatingSystemVersion") ?? GetData("client_Browser");
     public string? ClientCity => GetData("client_City");
     public string? ClientState => GetData("client_StateOrProvince");
     public string? ClientCountry => GetData("client_CountryOrRegion");

--- a/TinyInsights.Web/Services/Models/ErrorItem.cs
+++ b/TinyInsights.Web/Services/Models/ErrorItem.cs
@@ -12,7 +12,32 @@ public class ErrorItem : LogItem
     public string? ClientType => GetData("client_Type");
     public string? ClientModel => GetData("client_Model");
     public string? ClientOs => GetData("client_OS");
-    public string? ClientOsVersion => GetData("OperatingSystemVersion") ?? GetData("client_Browser");
+    public string? ClientOsVersion 
+    { 
+        get
+        {
+            var os = GetData("OperatingSystemVersion"); 
+            
+            if(os!= null)
+            {
+                return os;
+            }
+            
+            // For android it can be forexample Android 14.
+            var browser = GetData("client_Browser");
+            
+            if(browser != null)
+            {
+                var split = browser.Split(" ");
+                if(split.Length > 1 && double.TryParse(split[1], out var version))
+                {
+                    return version.ToString();
+                }
+            }
+
+            return null;
+        }
+    }
     public string? ClientCity => GetData("client_City");
     public string? ClientState => GetData("client_StateOrProvince");
     public string? ClientCountry => GetData("client_CountryOrRegion");


### PR DESCRIPTION
I added `escapedId` in the query to replace only the `'` character. I’m not sure if there are any other special characters, but this fixed issue #10.

I also added `GetData("client_Browser");` to the ErrorItem because, in some Android versions, OperatingSystemVersion does not contain the value, but client_Browser does.

Let me know if you need further revisions!