### PR TITLE
Add ability to add or update global properties

### DIFF
--- a/TinyInsights.Web/Services/InsightsService.Analytics.cs
+++ b/TinyInsights.Web/Services/InsightsService.Analytics.cs
@@ -56,7 +56,7 @@ public partial class InsightsService
     public Task<List<CountPerKey>> GetUserPerLanguage(GlobalFilter filter)
     {
         var queryFilter = GetFilter(filter);
-        var query = $"pageViews | extend language = tostring(customDimensions.Language) | where{queryFilter} timestamp > ago({filter.NumberOfDays}d) | summarize PageViewsCount = dcount(user_Id) by language";
+        var query = $"pageViews | extend language = tostring(customDimensions.Language) | where{queryFilter} timestamp > ago({filter.NumberOfDays}d) | summarize arg_max(timestamp, *) by user_Id | summarize PageViewsCount = dcount(user_Id) by language";
 
         return GetPerKeyResult(query);
     }

--- a/TinyInsights.Web/TinyInsights.Web.csproj
+++ b/TinyInsights.Web/TinyInsights.Web.csproj
@@ -4,8 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-
-       
     </PropertyGroup>
 
     <ItemGroup>

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -98,7 +98,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     }
 #endif
 
-    public void AddGlobalProperty(string key, string value)
+    public void UpsertGlobalProperty(string key, string value)
     {
         client.Context.GlobalProperties[key] = value;
     }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -98,6 +98,11 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     }
 #endif
 
+    public void AddGlobalProperty(string key, string value)
+    {
+        client.Context.GlobalProperties[key] = value;
+    }
+
     public void OverrideAnonymousUserId(string userId)
     {
         SetUserId(userId);

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -4,6 +4,8 @@ public interface IInsights
 {
     void AddProvider(IInsightsProvider provider);
 
+    void AddGlobalProperty(string key, string value);
+
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 
     Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -4,7 +4,7 @@ public interface IInsights
 {
     void AddProvider(IInsightsProvider provider);
 
-    void AddGlobalProperty(string key, string value);
+    void UpsertGlobalProperty(string key, string value);
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -8,6 +8,8 @@ public interface IInsightsProvider
     bool IsTrackEventsEnabled { get; set; }
     bool IsTrackDependencyEnabled { get; set; }
 
+    void AddGlobalProperty(string key, string value);
+
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 
     Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -8,7 +8,7 @@ public interface IInsightsProvider
     bool IsTrackEventsEnabled { get; set; }
     bool IsTrackDependencyEnabled { get; set; }
 
-    void AddGlobalProperty(string key, string value);
+    void UpsertGlobalProperty(string key, string value);
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -4,6 +4,14 @@ public class Insights : IInsights
 {
     private readonly List<IInsightsProvider> insightsProviders = new();
 
+    public void AddGlobalProperty(string key, string value)
+    {
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
+        {
+            provider.AddGlobalProperty(key, value);
+        }
+    }
+
     public void AddProvider(IInsightsProvider provider)
     {
         insightsProviders.Add(provider);

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -4,11 +4,11 @@ public class Insights : IInsights
 {
     private readonly List<IInsightsProvider> insightsProviders = new();
 
-    public void AddGlobalProperty(string key, string value)
+    public void UpsertGlobalProperty(string key, string value)
     {
         foreach(var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
         {
-            provider.AddGlobalProperty(key, value);
+            provider.UpsertGlobalProperty(key, value);
         }
     }
 


### PR DESCRIPTION
My used case:
> In our app we have the ability to allow the user to set the language the app uses manually. 
>
> Currently, the code sets the language based on the current culture at startup - 
https://github.com/dhindrik/TinyInsights.Maui/blob/f94ee43e1c771fa3ec4213e4afdaa10276db0b89/TinyInsights/ApplicationInsightsProvider.cs#L141C8-L141C115
> 
> This happens before we set the app to the users saved preferred language, and the user could change the language at any point.
> 
> Meaning the stats in the application doesn't reflect the actual app settings

There are 2 changes in this PR -
- Added `UpsertGlobalProperty`
    - This either Adds or Updates a property in the global properties dictionary. 
    - i.e. i can use this to override the preset language `insights.UpsertGlobalProperty("Language", AppSettings.SelectedLanguage)`
    - It can also be used for other cases, f.e. we'd like to record the users theme so we can see whats the most used etc
- Update the language query on the dashboard
    - Add `| summarize arg_max(timestamp, *) by user_Id`
    - This gets the last pageView event for the user, without this even with just one user the dashboard was showing 2 languages being used -   
![image](https://github.com/user-attachments/assets/7eae1078-da52-4c99-b1e7-7416a22aa137)
    - It now just counts the latest language used by each user -
![image](https://github.com/user-attachments/assets/80dbb944-23f2-4729-82bd-83d9ddfe26fd)


