### PR TITLE
Automatic page view tracking

### DIFF
--- a/TinyInsights.TestApp/MainPage.xaml
+++ b/TinyInsights.TestApp/MainPage.xaml
@@ -1,23 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="TinyInsights.TestApp.MainPage">
+<ContentPage
+    x:Class="TinyInsights.TestApp.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
     <ScrollView Padding="20">
-        <VerticalStackLayout
-            Spacing="25">
-          <HorizontalStackLayout Spacing="10">
-          
-            <Switch IsToggled="{Binding UseILogger, Mode=TwoWay}" />
-            <Label Text="Use ILogger" />
-</HorizontalStackLayout>
-            <Button x:Name="PageViewButton" Text="Track page view" Clicked="PageViewButton_OnClicked" />
-            
-            <Button x:Name="EventButton" Text="Track event" Clicked="EventButton_OnClicked" />
-            <Button x:Name="ExceptionButton" Text="Track exception" Clicked="ExceptionButton_OnClicked" />
-            <Button x:Name="TrackHttpButton" Text="Track http request" Clicked="TrackHttpButton_OnClicked" />
-            <Button x:Name="CrashButtom" Text="Crash app" Clicked="CrashButtom_OnClicked" />
-            <Button  Text="Test page automatic page tracking" Clicked="NewPageButton_Clicked" />
+        <VerticalStackLayout Spacing="25">
+            <HorizontalStackLayout Spacing="10">
+
+                <Switch IsToggled="{Binding UseILogger, Mode=TwoWay}" />
+                <Label Text="Use ILogger" />
+            </HorizontalStackLayout>
+            <Button
+                x:Name="PageViewButton"
+                Clicked="PageViewButton_OnClicked"
+                Text="Track page view" />
+
+            <Button
+                x:Name="EventButton"
+                Clicked="EventButton_OnClicked"
+                Text="Track event" />
+            <Button
+                x:Name="ExceptionButton"
+                Clicked="ExceptionButton_OnClicked"
+                Text="Track exception" />
+            <Button
+                x:Name="TrackHttpButton"
+                Clicked="TrackHttpButton_OnClicked"
+                Text="Track http request" />
+            <Button
+                x:Name="CrashButtom"
+                Clicked="CrashButtom_OnClicked"
+                Text="Crash app" />
+            <Button Clicked="NewPageButton_Clicked" Text="Test page automatic page tracking" />
+
+            <Button Clicked="Button_Clicked" Text="clear gc" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/TinyInsights.TestApp/MainPage.xaml
+++ b/TinyInsights.TestApp/MainPage.xaml
@@ -17,6 +17,7 @@
             <Button x:Name="ExceptionButton" Text="Track exception" Clicked="ExceptionButton_OnClicked" />
             <Button x:Name="TrackHttpButton" Text="Track http request" Clicked="TrackHttpButton_OnClicked" />
             <Button x:Name="CrashButtom" Text="Crash app" Clicked="CrashButtom_OnClicked" />
+            <Button  Text="Test page automatic page tracking" Clicked="NewPageButton_Clicked" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace TinyInsights.TestApp;
 
@@ -18,8 +19,6 @@ public partial class MainPage : ContentPage
         insights.OverrideAnonymousUserId("TestUser");
 
         InitializeComponent();
-
-
     }
 
     private bool useILogger;
@@ -99,5 +98,10 @@ public partial class MainPage : ContentPage
     private async void NewPageButton_Clicked(object sender, EventArgs e)
     {
         await Navigation.PushAsync(new NewPage());
+    }
+
+    private void Button_Clicked(object sender, EventArgs e)
+    {
+        Debug.WriteLine($"Memory: {GC.GetTotalMemory(true)}");
     }
 }

--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -95,4 +95,9 @@ public partial class MainPage : ContentPage
     {
         throw new Exception("Crash Boom Bang!");
     }
+
+    private async void NewPageButton_Clicked(object sender, EventArgs e)
+    {
+        await Navigation.PushAsync(new NewPage());
+    }
 }

--- a/TinyInsights.TestApp/MauiProgram.cs
+++ b/TinyInsights.TestApp/MauiProgram.cs
@@ -23,6 +23,8 @@ public static class MauiProgram
                     provider.IsAutoTrackPageViewsEnabled = true;
                     provider.IsTrackEventsEnabled = true;
                     provider.IsTrackDependencyEnabled = true;
+                    provider.IsAutoTrackPageViewsEnabled = true;
+                    ;
                 })
             .UseTinyInsightsAsILogger("InstrumentationKey=8b51208f-7926-4b7b-9867-16989206b950;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/;ApplicationId=0c04d3a0-9ee2-41a5-996e-526552dc730f");
 

--- a/TinyInsights.TestApp/MauiProgram.cs
+++ b/TinyInsights.TestApp/MauiProgram.cs
@@ -17,11 +17,12 @@ public static class MauiProgram
             .UseTinyInsights("InstrumentationKey=8b51208f-7926-4b7b-9867-16989206b950;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/;ApplicationId=0c04d3a0-9ee2-41a5-996e-526552dc730f",
                 (provider) =>
                 {
-                    provider.IsTrackDependencyEnabled = true;
-                    provider.IsTrackEventsEnabled = true;
                     provider.IsTrackErrorsEnabled = true;
-                    provider.IsTrackPageViewsEnabled = true;
                     provider.IsTrackCrashesEnabled = true;
+                    provider.IsTrackPageViewsEnabled = true;
+                    provider.IsAutoTrackPageViewsEnabled = true;
+                    provider.IsTrackEventsEnabled = true;
+                    provider.IsTrackDependencyEnabled = true;
                 })
             .UseTinyInsightsAsILogger("InstrumentationKey=8b51208f-7926-4b7b-9867-16989206b950;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/;ApplicationId=0c04d3a0-9ee2-41a5-996e-526552dc730f");
 

--- a/TinyInsights.TestApp/NewPage.xaml
+++ b/TinyInsights.TestApp/NewPage.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="TinyInsights.TestApp.NewPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    Title="NewPage">
+    <VerticalStackLayout>
+        <Label
+            HorizontalOptions="Center"
+            Text="Welcome to .NET MAUI!"
+            VerticalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/TinyInsights.TestApp/NewPage.xaml
+++ b/TinyInsights.TestApp/NewPage.xaml
@@ -9,5 +9,7 @@
             HorizontalOptions="Center"
             Text="Welcome to .NET MAUI!"
             VerticalOptions="Center" />
+
+        <Button Clicked="Button_Clicked" Text="Next page" />
     </VerticalStackLayout>
 </ContentPage>

--- a/TinyInsights.TestApp/NewPage.xaml.cs
+++ b/TinyInsights.TestApp/NewPage.xaml.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace TinyInsights.TestApp;
 
 public partial class NewPage : ContentPage
@@ -5,5 +7,22 @@ public partial class NewPage : ContentPage
 	public NewPage()
 	{
 		InitializeComponent();
-	}
+
+        Appearing += (_,_) =>
+        {
+            Debug.WriteLine("NewPage Appearing event");
+        };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+        Debug.WriteLine("NewPage OnAppearing override");
+    }
+
+    private async void Button_Clicked(object sender, EventArgs e)
+    {
+		await Navigation.PushAsync(new NewPage1());
+    }
 }

--- a/TinyInsights.TestApp/NewPage.xaml.cs
+++ b/TinyInsights.TestApp/NewPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace TinyInsights.TestApp;
+
+public partial class NewPage : ContentPage
+{
+	public NewPage()
+	{
+		InitializeComponent();
+	}
+}

--- a/TinyInsights.TestApp/NewPage1.xaml
+++ b/TinyInsights.TestApp/NewPage1.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TinyInsights.TestApp.NewPage1"
+             Title="NewPage1">
+    <VerticalStackLayout>
+        <Label 
+            Text="Welcome to .NET MAUI!"
+            VerticalOptions="Center" 
+            HorizontalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/TinyInsights.TestApp/NewPage1.xaml.cs
+++ b/TinyInsights.TestApp/NewPage1.xaml.cs
@@ -1,0 +1,9 @@
+namespace TinyInsights.TestApp;
+
+public partial class NewPage1 : ContentPage
+{
+	public NewPage1()
+	{
+		InitializeComponent();
+	}
+}

--- a/TinyInsights.TestApp/TinyInsights.TestApp.csproj
+++ b/TinyInsights.TestApp/TinyInsights.TestApp.csproj
@@ -39,30 +39,36 @@
 
     <ItemGroup>
         <!-- App Icon -->
-        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4"/>
+        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
         <!-- Splash Screen -->
-        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128"/>
+        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
         <!-- Images -->
-        <MauiImage Include="Resources\Images\*"/>
-        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185"/>
+        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
 
         <!-- Custom Fonts -->
-        <MauiFont Include="Resources\Fonts\*"/>
+        <MauiFont Include="Resources\Fonts\*" />
 
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)"/>
+        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\TinyInsights\TinyInsights.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <MauiXaml Update="NewPage.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </MauiXaml>
     </ItemGroup>
 
 </Project>

--- a/TinyInsights.TestApp/TinyInsights.TestApp.csproj
+++ b/TinyInsights.TestApp/TinyInsights.TestApp.csproj
@@ -69,6 +69,9 @@
       <MauiXaml Update="NewPage.xaml">
         <Generator>MSBuild:Compile</Generator>
       </MauiXaml>
+      <MauiXaml Update="NewPage1.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </MauiXaml>
     </ItemGroup>
 
 </Project>

--- a/TinyInsights.Web/Pages/ErrorDetails.razor
+++ b/TinyInsights.Web/Pages/ErrorDetails.razor
@@ -1,15 +1,18 @@
 @page "/diagnostics/crashes/details/{*Id}"
 @page "/diagnostics/errors/details/{*Id}"
+@using System.Web
+@using System.Text.RegularExpressions
 
 @inherits TinyInsightsComponentBase
 
 @inject IInsightsService Service
 @inject DialogService DialogService
 
+
 <RadzenStack>
     <RadzenRow JustifyContent="JustifyContent.SpaceBetween" AlignItems="AlignItems.Center">
         <a href="@backUrl" title="Back">
-            <RadzenIcon Icon="arrow_back"/>
+            <RadzenIcon Icon="arrow_back" />
         </a>
         <GlobalFilters />
 
@@ -20,53 +23,53 @@
 
         @if (isLoading)
         {
-            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate"/>
+            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
         }
         else
         {
             <RadzenStack Orientation="Orientation.Horizontal" Wrap="FlexWrap.Wrap" Gap="20px">
-                <LabelValuePair Key="Count" Value="@data.Count.ToString()"/>
-                <LabelValuePair Key="Affected users" Value="@data.AffectedUsersCount.ToString()"/>
-                <LabelValuePair Key="Affected app versions" Value="@(string.Join(", ", data.AffectedAppVersions))"/>
-                <LabelValuePair Key="Affected operating systems" Value="@(string.Join(", ", data.AffectedOperatingSystems))"/>
+                <LabelValuePair Key="Count" Value="@data.Count.ToString()" />
+                <LabelValuePair Key="Affected users" Value="@data.AffectedUsersCount.ToString()" />
+                <LabelValuePair Key="Affected app versions" Value="@(string.Join(", ", data.AffectedAppVersions))" />
+                <LabelValuePair Key="Affected operating systems" Value="@(string.Join(", ", data.AffectedOperatingSystems))" />
             </RadzenStack>
         }
 
     </RadzenCard>
     <RadzenCard>
-    <h2>Message</h2>
+        <h2>Message</h2>
         @if (isLoading)
         {
-            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate"/>
+            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
         }
         else
         {
             <p class="stacktrace">
-            @if (data.Items.Count > 0 && data.Items.First().Message is not null)
-            {
-                @data.Items.First().Message
-
-            }
-            else
-            {
-                <span>No message available</span>
-            }
-         </p>
-    }
+                @if (data.Items.Count > 0 && data.Items.First().Message is not null)
+                {
+                    @data.Items.First().Message
+                }
+                else
+                {
+                    <span>No message available</span>
+                }
+            </p>
+        }
     </RadzenCard>
     <RadzenCard>
         <h2>Stacktrace</h2>
         @if (isLoading)
         {
-        <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate"/>
-}
+            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
+        }
         else
         {
             <p class="stacktrace">
                 @if (data.Items.Count > 0 && data.Items.First().StackTrace is not null)
                 {
-                    @data.Items.First().StackTrace
-
+                    <code>
+                        @((MarkupString)Regex.Replace(HttpUtility.HtmlEncode(@data.Items.First().StackTrace ?? string.Empty), "\r?\n|\r", "<br />"));
+                    </code>
                 }
                 else
                 {
@@ -79,25 +82,25 @@
         <h2>@listHeader</h2>
         @if (isLoading)
         {
-        <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate"/>
+            <RadzenProgressBarCircular Value="100" ShowValue="false" Mode="ProgressBarMode.Indeterminate" />
         }
         else
         {
             <RadzenDataGrid Data="data.Items">
                 <Columns>
-                    <RadzenDataGridColumn TItem="ErrorItem" Title="Timestamp" Property="@nameof(ErrorItem.Timestamp)"/>
-                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device" Property="@nameof(ErrorItem.ClientModel)"/>
-                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device OS" Property="@nameof(ErrorItem.ClientOs)"/>
-                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device OS version" Property="@nameof(ErrorItem.ClientOsVersion)"/>
-                    <RadzenDataGridColumn TItem="ErrorItem" Title="Country" Property="@nameof(ErrorItem.ClientCountry)"/>
+                    <RadzenDataGridColumn TItem="ErrorItem" Title="Timestamp" Property="@nameof(ErrorItem.Timestamp)" />
+                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device" Property="@nameof(ErrorItem.ClientModel)" />
+                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device OS" Property="@nameof(ErrorItem.ClientOs)" />
+                    <RadzenDataGridColumn TItem="ErrorItem" Title="Device OS version" Property="@nameof(ErrorItem.ClientOsVersion)" />
+                    <RadzenDataGridColumn TItem="ErrorItem" Title="Country" Property="@nameof(ErrorItem.ClientCountry)" />
                     <RadzenDataGridColumn TItem="ErrorItem" Width="100px">
                         <Template>
-                            <RadzenButton Icon="description" Click="@(async (args) => await ShowAllProperties(context))"/>
+                            <RadzenButton Icon="description" Click="@(async (args) => await ShowAllProperties(context))" />
                         </Template>
                     </RadzenDataGridColumn>
                     <RadzenDataGridColumn TItem="ErrorItem" Width="100px">
                         <Template>
-                            <RadzenButton Icon="format_list_numbered" Click="@(async (args) => await ShowEvents(context))"/>
+                            <RadzenButton Icon="format_list_numbered" Click="@(async (args) => await ShowEvents(context))" />
                         </Template>
                     </RadzenDataGridColumn>
                 </Columns>
@@ -110,16 +113,16 @@
 @code {
     [Parameter]
     public required string Id { get; set; }
-    
+
     [CascadingParameter]
     public required GlobalFilter GlobalFilter { get; set; }
 
     private bool isLoading = true;
     private bool isCrash;
-    private string backUrl = string.Empty,detailsHeader = string.Empty, listHeader = string.Empty;
+    private string backUrl = string.Empty, detailsHeader = string.Empty, listHeader = string.Empty;
 
     private Services.Models.ErrorDetails data = new();
-    
+
     protected override async Task OnParametersSetAsync()
     {
         await base.OnParametersSetAsync();
@@ -162,14 +165,14 @@
     {
         await DialogService.OpenAsync<AllProperties>($"All properties",
             new Dictionary<string, object>() { { "Properties", item.Data } },
-            new DialogOptions() { Width = "700px", Height = "512px", Resizable = true, Draggable = true});
+            new DialogOptions() { Width = "700px", Height = "512px", Resizable = true, Draggable = true });
     }
-    
+
     private async Task ShowEvents(ErrorItem item)
     {
         await DialogService.OpenAsync<Events>($"Recent events",
             new Dictionary<string, object>() { { "UserId", item.UserId }, { "Timestamp", item.Timestamp } },
-            new DialogOptions() { Width = "700px", Height = "512px", Resizable = true, Draggable = true});
+            new DialogOptions() { Width = "700px", Height = "512px", Resizable = true, Draggable = true });
     }
 }
 

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -156,41 +156,36 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            Debug.WriteLine("TinyInsights: Sending crashes");
-
             var crashes = ReadCrashes();
 
-            if(crashes is null)
+            if(crashes is null || crashes.Count == 0)
             {
                 return;
             }
 
-            if(crashes.Count > 0)
+            Debug.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
+
+            foreach(var crash in crashes)
             {
-                Debug.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
+                var ex = crash.GetException();
 
-                foreach(var crash in crashes)
+                if (ex is null)
                 {
-                    var ex = crash.GetException();
-
-                    if (ex is null)
-                    {
-                        continue;
-                    }
-
-                    var properties = new Dictionary<string, string>
-                    {
-                        { "IsCrash", "true" },
-                        { "StackTrace", crash.StackTrace ?? string.Empty },
-                        { "ExceptionType", crash.ExceptionType },
-                        { "Source", crash.Source ?? string.Empty }
-                    };
-
-                    await TrackErrorAsync(ex, properties);
+                    continue;
                 }
 
-                ResetCrashes();
+                var properties = new Dictionary<string, string>
+                {
+                    { "IsCrash", "true" },
+                    { "StackTrace", crash.StackTrace ?? string.Empty },
+                    { "ExceptionType", crash.ExceptionType },
+                    { "Source", crash.Source ?? string.Empty }
+                };
+
+                await TrackErrorAsync(ex, properties);
             }
+
+            ResetCrashes();
         }
         catch(Exception)
         {

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -43,6 +43,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error creating TelemetryClient");
         }
 
         Task.Run(SendCrashes);
@@ -82,6 +83,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error creating TelemetryClient");
         }
 
         AddMetaData();
@@ -154,6 +156,8 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
+            Debug.WriteLine("TinyInsights: Sending crashes");
+
             var crashes = ReadCrashes();
 
             if (crashes.Count > 0)
@@ -179,6 +183,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error sending crashes");
         }
     }
 
@@ -186,6 +191,8 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
+            Debug.WriteLine("TinyInsights: Read crashes");
+
             var path = Path.Combine(logPath, crashLogFilename);
 
             if (!File.Exists(path))
@@ -205,6 +212,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error reading crashes");
         }
 
         return new List<Crash>();
@@ -214,11 +222,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
+            Debug.WriteLine("TinyInsights: Reset crashes");
+
             var path = Path.Combine(logPath, crashLogFilename);
             File.Delete(path);
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error clearing crashes");
         }
     }
 
@@ -226,6 +237,8 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
+            Debug.WriteLine("TinyInsights: Handle crashes");
+
             var crashes = ReadCrashes();
 
             crashes.Add(new Crash(ex));
@@ -238,6 +251,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error handling crashes");
         }
     }
 
@@ -259,6 +273,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
         catch (Exception)
         {
+            Debug.WriteLine("TinyInsights: Error tracking error");
         }
 
         return Task.CompletedTask;
@@ -273,9 +288,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.TrackEvent(eventName, properties);
             client.Flush();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-
+            Debug.WriteLine("TinyInsights: Error tracking event");
         }
 
         return Task.CompletedTask;
@@ -285,14 +300,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            Debug.WriteLine($"TinyInsights: Tracking page view {viewName}");
+            Debug.WriteLine($"TinyInsights: tracking page view {viewName}");
 
             client.TrackPageView(viewName);
             client.Flush();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-
+            Debug.WriteLine("TinyInsights: Error tracking page view");
         }
 
         return Task.CompletedTask;
@@ -344,9 +359,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             client.TrackDependency(dependency);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-
+            Debug.WriteLine("TinyInsights: Error tracking dependency");
         }
 
         return Task.CompletedTask;

--- a/TinyInsights/Crash.cs
+++ b/TinyInsights/Crash.cs
@@ -2,10 +2,6 @@ namespace TinyInsights;
 
 public class Crash
 {
-    public Crash()
-    {
-    }
-
     public Crash(Exception exception)
     {
         Message = exception.Message;
@@ -15,14 +11,25 @@ public class Crash
     }
 
     public string Message { get; init; }
-    public string StackTrace { get; init; }
+    public string? StackTrace { get; init; }
     public string ExceptionType { get; init; }
-    public string Source { get; init; }
+    public string? Source { get; init; }
 
-    public Exception GetException()
+    public Exception? GetException()
     {
-        var ex = (Exception)Activator.CreateInstance(Type.GetType(ExceptionType), args: Message);
-        ex.Source = Source;
+        var type = Type.GetType(ExceptionType);
+
+        if(type is null)
+        {
+            return null;
+        }
+
+        var ex = Activator.CreateInstance(type, args: Message) as Exception;
+
+        if(ex is not null)
+        {
+            ex.Source = Source;
+        }
 
         return ex;
     }

--- a/TinyInsights/Dependency.cs
+++ b/TinyInsights/Dependency.cs
@@ -10,14 +10,14 @@ public class Dependency : IDisposable
         StartTime = DateTimeOffset.Now;
     }
 
-    public string DependencyType { get; internal set; }
-    public string DependencyName { get; internal set; }
-    public string Data { get; internal set; }
+    public string DependencyType { get; internal set; } = string.Empty;
+    public string DependencyName { get; internal set; } = string.Empty;
+    public string Data { get; internal set; } = string.Empty;
     public DateTimeOffset StartTime { get; private set; }
     public TimeSpan Duration { get; private set; }
     public HttpMethod? HttpMethod { get; internal set; }
 
-    private SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+    private readonly SemaphoreSlim semaphore = new(1, 1);
 
     private bool isFinished;
 
@@ -26,25 +26,25 @@ public class Dependency : IDisposable
         Task.Run(() => Finish(true));
     }
 
-    public Task Finish(bool sucess, int resultCode = 0)
+    public Task Finish(bool success, int resultCode = 0)
     {
-        return Finish(sucess, resultCode, null);
+        return Finish(success, resultCode, null);
     }
 
-    public Task Finish(bool sucess, Exception exception)
+    public Task Finish(bool success, Exception exception)
     {
-        return Finish(sucess, 0, exception);
+        return Finish(success, 0, exception);
     }
 
-    public async Task Finish(bool sucess, int resultCode, Exception exception = null)
+    public async Task Finish(bool success, int resultCode, Exception? exception = null)
     {
         await semaphore.WaitAsync();
 
-        if (!isFinished)
+        if(!isFinished)
         {
             Duration = DateTimeOffset.Now - StartTime;
 
-            await insights.TrackDependencyAsync(DependencyType, DependencyName, Data, HttpMethod, StartTime, Duration, sucess, resultCode, exception);
+            await insights.TrackDependencyAsync(DependencyType, DependencyName, Data, HttpMethod, StartTime, Duration, success, resultCode, exception);
 
             isFinished = true;
 

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -13,9 +13,13 @@ public interface IInsights
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
+
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, HttpMethod? httpMethod, DateTimeOffset startTime, TimeSpan duration,
        bool success, int resultCode = 0, Exception? exception = null);
+
     Dependency CreateDependencyTracker(string dependencyType, string dependencyName, string data);
+
     void OverrideAnonymousUserId(string userId);
+
     void GenerateNewAnonymousUserId();
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -5,6 +5,7 @@ public interface IInsightsProvider
     bool IsTrackErrorsEnabled { get; set; }
     public bool IsTrackCrashesEnabled { get; set; }
     bool IsTrackPageViewsEnabled { get; set; }
+    bool IsAutoTrackPageViewsEnabled { get; set; }
     bool IsTrackEventsEnabled { get; set; }
     bool IsTrackDependencyEnabled { get; set; }
 

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -9,6 +9,8 @@ public interface IInsightsProvider
     bool IsTrackEventsEnabled { get; set; }
     bool IsTrackDependencyEnabled { get; set; }
 
+    void ConfigureAutoPageTracking();
+
     void UpsertGlobalProperty(string key, string value);
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -17,7 +17,10 @@ public interface IInsightsProvider
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, HttpMethod? httpMethod, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
+
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
+
     void OverrideAnonymousUserId(string userId);
+
     void GenerateNewAnonymousUserId();
 }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -2,7 +2,7 @@ namespace TinyInsights;
 
 public class Insights : IInsights
 {
-    private readonly List<IInsightsProvider> insightsProviders = new();
+    private readonly List<IInsightsProvider> insightsProviders = [];
 
     public void UpsertGlobalProperty(string key, string value)
     {
@@ -21,7 +21,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
         {
             var task = provider.TrackErrorAsync(ex, properties);
             tasks.Add(task);
@@ -36,7 +36,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
         {
             var task = provider.TrackPageViewAsync(viewName, properties);
             tasks.Add(task);
@@ -50,7 +50,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
         {
             var task = provider.TrackEventAsync(eventName, properties);
             tasks.Add(task);
@@ -72,7 +72,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
         {
             var task = provider.TrackDependencyAsync(dependencyType, dependencyName, data, httpMethod, startTime, duration, success, resultCode, exception);
             tasks.Add(task);
@@ -85,32 +85,28 @@ public class Insights : IInsights
 
     public Dependency CreateDependencyTracker(string dependencyType, string dependencyName, string data)
     {
-        var dependency = new Dependency(this)
+        return new Dependency(this)
         {
             DependencyType = dependencyType,
             DependencyName = dependencyName,
             Data = data
         };
-
-        return dependency;
     }
 
     public Dependency CreateDependencyTracker(string dependencyType, string dependencyName, string data, HttpMethod httpMethod)
     {
-        var dependency = new Dependency(this)
+        return new Dependency(this)
         {
             DependencyType = dependencyType,
             DependencyName = dependencyName,
             Data = data,
             HttpMethod = httpMethod
         };
-
-        return dependency;
     }
 
     public void OverrideAnonymousUserId(string userId)
     {
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
         {
             provider.OverrideAnonymousUserId(userId);
         }
@@ -118,7 +114,7 @@ public class Insights : IInsights
 
     public void GenerateNewAnonymousUserId()
     {
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
         {
             provider.GenerateNewAnonymousUserId();
         }

--- a/TinyInsights/InsightsExtension.cs
+++ b/TinyInsights/InsightsExtension.cs
@@ -23,6 +23,8 @@ public static class InsightsExtension
 #endif
             configureProvider?.Invoke(provider);
 
+            provider.ConfigureAutoPageTracking();
+
             var insights = new Insights();
             insights.AddProvider(provider);
 

--- a/TinyInsights/InsightsExtension.cs
+++ b/TinyInsights/InsightsExtension.cs
@@ -13,8 +13,7 @@ public static class InsightsExtension
 
     public static MauiAppBuilder UseTinyInsights(this MauiAppBuilder appBuilder, string applicationInsightsConnectionString, Action<IInsightsProvider>? configureProvider = null)
     {
-
-        appBuilder.Services.AddSingleton<IInsights>((services) =>
+        appBuilder.Services.AddSingleton<IInsights>((_) =>
         {
 #if WINDOWS
 
@@ -37,8 +36,7 @@ public static class InsightsExtension
 
     public static MauiAppBuilder UseTinyInsightsAsILogger(this MauiAppBuilder appBuilder, string applicationInsightsConnectionString, Action<IInsightsProvider>? configureProvider = null)
     {
-
-        appBuilder.Services.AddSingleton<ILogger>((services) =>
+        appBuilder.Services.AddSingleton<ILogger>((_) =>
         {
 #if WINDOWS
             var provider = new ApplicationInsightsProvider(MauiWinUIApplication.Current, applicationInsightsConnectionString);
@@ -55,5 +53,4 @@ public static class InsightsExtension
 
         return appBuilder;
     }
-
 }

--- a/TinyInsights/InsightsMessageHandler.cs
+++ b/TinyInsights/InsightsMessageHandler.cs
@@ -27,34 +27,34 @@ public class InsightsMessageHandler : DelegatingHandler
             {
                 response.EnsureSuccessStatusCode();
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 exception = e;
             }
 
             await insights.TrackDependencyAsync(
-                "HTTP", 
-                request.RequestUri?.Host ?? "Unknown host", 
-                request.RequestUri?.ToString() ?? string.Empty, 
-                request.Method, 
-                startTime, 
+                "HTTP",
+                request.RequestUri?.Host ?? "Unknown host",
+                request.RequestUri?.ToString() ?? string.Empty,
+                request.Method,
+                startTime,
                 endTime - startTime,
                 response.IsSuccessStatusCode,
-                (int)response.StatusCode, 
+                (int)response.StatusCode,
                 exception);
 
             return response;
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             var endTime = DateTime.Now;
             await insights.TrackDependencyAsync(
-                "HTTP", 
-                request.RequestUri?.Host ?? "Unknown host", 
-                request.RequestUri?.ToString() ?? string.Empty, 
+                "HTTP",
+                request.RequestUri?.Host ?? "Unknown host",
+                request.RequestUri?.ToString() ?? string.Empty,
                 startTime,
                 endTime - startTime,
-                false, 
+                false,
                 0,
                 ex);
 

--- a/TinyInsights/InsightsMessageHandler.cs
+++ b/TinyInsights/InsightsMessageHandler.cs
@@ -32,16 +32,31 @@ public class InsightsMessageHandler : DelegatingHandler
                 exception = e;
             }
 
-            await insights.TrackDependencyAsync("HTTP", request.RequestUri.Host, request.RequestUri.ToString(), request.Method, startTime, endTime - startTime,
-                response.IsSuccessStatusCode, (int)response.StatusCode, exception);
+            await insights.TrackDependencyAsync(
+                "HTTP", 
+                request.RequestUri?.Host ?? "Unknown host", 
+                request.RequestUri?.ToString() ?? string.Empty, 
+                request.Method, 
+                startTime, 
+                endTime - startTime,
+                response.IsSuccessStatusCode,
+                (int)response.StatusCode, 
+                exception);
 
             return response;
         }
         catch (Exception ex)
         {
             var endTime = DateTime.Now;
-            await insights.TrackDependencyAsync("HTTP", request.RequestUri.Host, request.RequestUri.ToString(), startTime, endTime - startTime,
-                false, 0, ex);
+            await insights.TrackDependencyAsync(
+                "HTTP", 
+                request.RequestUri?.Host ?? "Unknown host", 
+                request.RequestUri?.ToString() ?? string.Empty, 
+                startTime,
+                endTime - startTime,
+                false, 
+                0,
+                ex);
 
             throw;
         }

--- a/TinyInsights/WeakEventHandler.cs
+++ b/TinyInsights/WeakEventHandler.cs
@@ -1,0 +1,20 @@
+﻿namespace TinyInsights;
+
+internal class WeakEventHandler<TEventArgs>
+{
+    private readonly WeakReference<EventHandler<TEventArgs>> _weakHandler;
+
+    public WeakEventHandler(EventHandler<TEventArgs> handler)
+    {
+        _weakHandler = new WeakReference<EventHandler<TEventArgs>>(handler);
+    }
+
+    public void Handler(object sender, TEventArgs e)
+    {
+        if (_weakHandler.TryGetTarget(out var handler))
+        {
+            handler(sender, e);
+        }
+    }
+}
+


### PR DESCRIPTION
I added the ability to track page views automatically.

I've set the view name to the classes `FullName` rather than just `Name`. This is to avoid any issues with the stats.

f.e. in my use case we have 100s of pages and a lot of them are named the same, so if we used just `name` the page view count would be a lot higher, and no way of knowing what specific page is used.

It would also mess with application insights "Funnels" and "User flow" tools if the view name is not unique.