### PR TITLE
Fix: Read crashes

### DIFF
--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -7,13 +7,11 @@ public partial class MainPage : ContentPage
 {
     private readonly IInsights insights;
     private readonly InsightsMessageHandler insightsMessageHandler;
-    private readonly ILogger logger;
 
-    public MainPage(IInsights insights, InsightsMessageHandler insightsMessageHandler, ILogger logger)
+    public MainPage(IInsights insights, InsightsMessageHandler insightsMessageHandler)
     {
         this.insights = insights;
         this.insightsMessageHandler = insightsMessageHandler;
-        this.logger = logger;
 
         BindingContext = this;
         insights.OverrideAnonymousUserId("TestUser");
@@ -21,25 +19,8 @@ public partial class MainPage : ContentPage
         InitializeComponent();
     }
 
-    private bool useILogger;
-    public bool UseILogger
-    {
-        get => useILogger;
-        set
-        {
-            useILogger = value;
-            OnPropertyChanged(nameof(UseILogger));
-        }
-    }
-
     private async void PageViewButton_OnClicked(object? sender, EventArgs e)
     {
-        if (UseILogger)
-        {
-            logger.LogTrace("MainView");
-            return;
-        }
-
         var data = new Dictionary<string, string>()
         {
             {"key", "value"},
@@ -52,13 +33,6 @@ public partial class MainPage : ContentPage
 
     private async void EventButton_OnClicked(object? sender, EventArgs e)
     {
-        if (UseILogger)
-        {
-            logger.LogInformation("EventButton");
-            logger.LogDebug("EventButton clicked");
-            return;
-        }
-
         await insights.TrackEventAsync("EventButton");
     }
 
@@ -70,12 +44,6 @@ public partial class MainPage : ContentPage
         }
         catch (Exception ex)
         {
-            if (UseILogger)
-            {
-                logger.LogError(ex, ex.Message);
-                return;
-            }
-
             await insights.TrackErrorAsync(ex);
         }
     }

--- a/TinyInsights.TestApp/MauiProgram.cs
+++ b/TinyInsights.TestApp/MauiProgram.cs
@@ -24,8 +24,7 @@ public static class MauiProgram
                     provider.IsTrackEventsEnabled = true;
                     provider.IsTrackDependencyEnabled = true;
                     provider.IsAutoTrackPageViewsEnabled = true;
-                })
-            .UseTinyInsightsAsILogger("InstrumentationKey=8b51208f-7926-4b7b-9867-16989206b950;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/;ApplicationId=0c04d3a0-9ee2-41a5-996e-526552dc730f");
+                });
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/TinyInsights/Crash.cs
+++ b/TinyInsights/Crash.cs
@@ -2,6 +2,12 @@ namespace TinyInsights;
 
 public class Crash
 {
+    public Crash()
+    {
+        Message = string.Empty;
+        ExceptionType = string.Empty;
+    }
+
     public Crash(Exception exception)
     {
         Message = exception.Message;


### PR DESCRIPTION
Sorry in a previous PR I removed the empty constructor on the `Crash` model, as it didn't look like it was serving any purpose.

But it caused an exception to be throw when reading/ deserializing the crashes - 
```
Each parameter in the deserialization constructor on type 'TinyInsights.Crash' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled. The match can be case-insensitive.
```


I've also removed the ILogger implementation from the sample project, as it was causing issues debugging.
