### PR TITLE
Throw exception if it can't configure auto page tracking

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -82,8 +82,12 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             return;
         }
 
-        if(Application.Current is not null && IsAutoTrackPageViewsEnabled)
+        if(IsAutoTrackPageViewsEnabled)
         {
+            if(Application.Current is null)
+            {
+                throw new NullReferenceException("Unable to configure `IsAutoTrackPageViewsEnabled` as `Application.Current` is null. You can eihter set `IsAutoTrackPageViewsEnabled` to false to ignore this issue, or check out this link for a possible reason - https://github.com/dhindrik/TinyInsights.Maui/issues/21");
+            }
             WeakEventHandler<Page> weakHandler = new(OnAppearing);
             Application.Current.PageAppearing += weakHandler.Handler;
         }


### PR DESCRIPTION
Think it's better to throw an exception if it can't configure auto page tracking, than not showing anything to the developer.

With this PR, the developer will see an exception letting know what the issue is - 
![image](https://github.com/user-attachments/assets/388ba171-f7fd-4f21-9919-e3a4f8a84e05)
