### PR TITLE
Add net8.0 as TargetFramework

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -74,18 +74,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 #elif NET8_0_OR_GREATER
     public ApplicationInsightsProvider(string connectionString)
     {
-        _connectionString = connectionString;
-        provider = this;
-
-        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-
-        void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            if (IsTrackCrashesEnabled)
-            {
-                HandleCrash((Exception)e.ExceptionObject);
-            }
-        }
+        // Do nothing. The net8.0 target exists for enabling unit testing, not for actual use.
     }
 #endif
 

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -71,6 +71,22 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             }
         }
     }
+#elif NET8_0_OR_GREATER
+    public ApplicationInsightsProvider(string connectionString)
+    {
+        _connectionString = connectionString;
+        provider = this;
+
+        AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+
+        void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (IsTrackCrashesEnabled)
+            {
+                HandleCrash((Exception)e.ExceptionObject);
+            }
+        }
+    }
 #endif
 
     public static bool IsInitialized { get; private set; }

--- a/TinyInsights/TinyInsights.csproj
+++ b/TinyInsights/TinyInsights.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>


### PR DESCRIPTION
In my app I have net8.0 as a target frameworks besides the platforms I support. This helps with unit testing, as I can build the app as a dll-file and reference that from my unit test project. I want to unit test viewmodels and other logic and I have everything in the same Maui-project.

My csproj-file
 ```xml
    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios</TargetFrameworks>
    <OutputType Condition="'$(TargetFramework)' != 'net8.0'">Exe</OutputType>
 ```
 
This change adds net8.0 as a TargetFramework, enabling unit testing without having to add `#if ANDROID || IOS` whenever the IInsights interface is referenced.