### PR TITLE
UpsertGlobalProperty reliability

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -41,7 +41,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
-            if (IsTrackCrashesEnabled)
+            if(IsTrackCrashesEnabled)
             {
                 HandleCrash(e.Exception);
             }
@@ -49,7 +49,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            if (IsTrackCrashesEnabled)
+            if(IsTrackCrashesEnabled)
             {
                 HandleCrash((Exception)e.ExceptionObject);
             }
@@ -85,14 +85,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         CreateTelemetryClient();
 
-        if (IsInitialized)
+        if(IsInitialized)
         {
             return;
         }
 
-        if (IsAutoTrackPageViewsEnabled)
+        if(IsAutoTrackPageViewsEnabled)
         {
-            if (Application.Current is null)
+            if(Application.Current is null)
             {
                 throw new NullReferenceException("Unable to configure `IsAutoTrackPageViewsEnabled` as `Application.Current` is null. You can either set `IsAutoTrackPageViewsEnabled` to false to ignore this issue, or check out this link for a possible reason - https://github.com/dhindrik/TinyInsights.Maui/issues/21");
             }
@@ -115,14 +115,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     private TelemetryClient? CreateTelemetryClient()
     {
-        if (client is not null)
+        if(client is not null)
         {
             return client;
         }
 
         try
         {
-            if (string.IsNullOrWhiteSpace(ConnectionString))
+            if(string.IsNullOrWhiteSpace(ConnectionString))
             {
                 throw new ArgumentNullException("ConnectionString", "ConnectionString is required to initialize TinyInsights");
             }
@@ -144,9 +144,38 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.Context.User.Id = GetUserId();
 
             // Add any global properties, the user has already added
-            foreach (var property in _globalProperties)
+            foreach(var property in _globalProperties)
             {
-                client.Context.GlobalProperties[property.Key] = property.Value;
+                switch(property.Key)
+                {
+                    case "Cloud.RoleName":
+                        client.Context.Cloud.RoleName = property.Value;
+                        break;
+
+                    case "Cloud.RoleInstance":
+                        client.Context.Cloud.RoleInstance = property.Value;
+                        break;
+
+                    case "Device.OperatingSystem":
+                        client.Context.Device.OperatingSystem = property.Value;
+                        break;
+
+                    case "Device.Model":
+                        client.Context.Device.Model = property.Value;
+                        break;
+
+                    case "Device.Type":
+                        client.Context.Device.Type = property.Value;
+                        break;
+
+                    case "Device.Id":
+                        client.Context.Device.Id = property.Value;
+                        break;
+
+                    default:
+                        client.Context.GlobalProperties[property.Key] = property.Value;
+                        break;
+                }
             }
 
             client.Context.GlobalProperties.TryAdd("Language", CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
@@ -156,12 +185,11 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.Context.GlobalProperties.TryAdd("OperatingSystemVersion", DeviceInfo.VersionString);
             client.Context.Session.Id = Guid.NewGuid().ToString();
 
-
             return client;
         }
-        catch (Exception)
+        catch(Exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Error creating TelemetryClient");
         }
 
@@ -170,53 +198,58 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void UpsertGlobalProperty(string key, string value)
     {
-        if (Client is null)
+        _globalProperties[key] = value;
+
+        if(Client is null)
         {
             return;
         }
 
-        switch (key)
+        switch(key)
         {
             case "Cloud.RoleName":
                 Client.Context.Cloud.RoleName = value;
-                return;
+                break;
+
             case "Cloud.RoleInstance":
                 Client.Context.Cloud.RoleInstance = value;
-                return;
+                break;
 
             case "Device.OperatingSystem":
                 Client.Context.Device.OperatingSystem = value;
-                return;
+                break;
+
             case "Device.Model":
                 Client.Context.Device.Model = value;
-                return;
+                break;
+
             case "Device.Type":
                 Client.Context.Device.Type = value;
-                return;
+                break;
+
             case "Device.Id":
                 Client.Context.Device.Id = value;
-                return;
+                break;
+
+            default:
+                Client.Context.GlobalProperties[key] = value;
+                break;
         }
-
-        _globalProperties[key] = value;
-
-        Client.Context.GlobalProperties[key] = value;
-
     }
 
     public void RemoveGlobalProperty(string key)
     {
-        if (Client is null)
+        if(Client is null)
         {
             return;
         }
 
-        if (_globalProperties.ContainsKey(key))
+        if(_globalProperties.ContainsKey(key))
         {
             _globalProperties.Remove(key);
         }
 
-        if (Client.Context.GlobalProperties.ContainsKey(key))
+        if(Client.Context.GlobalProperties.ContainsKey(key))
         {
             Client.Context.GlobalProperties.Remove(key);
         }
@@ -225,7 +258,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     public void OverrideAnonymousUserId(string userId)
     {
         Preferences.Set(userIdKey, userId);
-        if (Client is not null)
+        if(Client is not null)
         {
             Client.Context.User.Id = userId;
         }
@@ -248,7 +281,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void CreateNewSession()
     {
-        if (Client is null)
+        if(Client is null)
         {
             return;
         }
@@ -260,26 +293,26 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
             var crashes = ReadCrashes();
 
-            if (crashes is null || crashes.Count == 0)
+            if(crashes is null || crashes.Count == 0)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
 
-            foreach (var crash in crashes)
+            foreach(var crash in crashes)
             {
                 var ex = crash.GetException();
 
-                if (ex is null)
+                if(ex is null)
                 {
                     continue;
                 }
@@ -297,9 +330,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             ResetCrashes();
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error sending crashes. Message: {ex.Message}");
         }
     }
@@ -312,7 +345,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             var path = Path.Combine(logPath, crashLogFilename);
 
-            if (!File.Exists(path))
+            if(!File.Exists(path))
             {
                 return null;
             }
@@ -321,7 +354,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             return string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<List<Crash>>(json);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             Trace.WriteLine($"TinyInsights: Error reading crashes. Message: {ex.Message}");
         }
@@ -333,15 +366,15 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Reset crashes");
 
             var path = Path.Combine(logPath, crashLogFilename);
             File.Delete(path);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error clearing crashes. Message: {ex.Message}");
         }
     }
@@ -350,7 +383,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Handle crashes");
 
             var crashes = ReadCrashes() ?? [];
@@ -363,9 +396,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             File.WriteAllText(path, json);
         }
-        catch (Exception exception)
+        catch(Exception exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error handling crashes. Message: {exception.Message}");
         }
     }
@@ -374,17 +407,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking error {ex.Message}");
 
             properties ??= [];
 
-            if (ex.StackTrace is not null)
+            if(ex.StackTrace is not null)
             {
                 properties.TryAdd("StackTrace", ex.StackTrace);
             }
@@ -392,9 +425,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackException(ex, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception exception)
+        catch(Exception exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking error. Message: {exception.Message}");
         }
     }
@@ -403,20 +436,20 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking event {eventName}");
 
             Client.TrackEvent(eventName, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking event. Message: {ex.Message}");
         }
     }
@@ -425,20 +458,20 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: tracking page view {viewName}");
 
             Client.TrackPageView(viewName);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking page view. Message: {ex.Message}");
         }
     }
@@ -447,17 +480,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking dependency {dependencyName}");
 
             var fullUrl = data;
 
-            if (data.Contains('?'))
+            if(data.Contains('?'))
             {
                 var split = data.Split("?");
                 data = split[0];
@@ -476,17 +509,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             dependency.Properties.Add("FullUrl", fullUrl);
 
-            if (httpMethod is not null)
+            if(httpMethod is not null)
             {
                 dependency.Properties.Add("HttpMethod", httpMethod.ToString());
             }
 
-            if (exception is not null)
+            if(exception is not null)
             {
                 dependency.Properties.Add("ExceptionMessage", exception.Message);
                 dependency.Properties.Add("StackTrace", exception.StackTrace);
 
-                if (exception.InnerException is not null)
+                if(exception.InnerException is not null)
                 {
                     dependency.Properties.Add("InnerExceptionMessage", exception.InnerException.Message);
                     dependency.Properties.Add("InnerExceptionStackTrace", exception.InnerException.StackTrace);
@@ -496,9 +529,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackDependency(dependency);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking dependency. Message: {ex.Message}");
         }
     }
@@ -512,7 +545,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public async void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (!IsEnabled(logLevel))
+        if(!IsEnabled(logLevel))
         {
             return;
         }


### PR DESCRIPTION
Currently if a dev tries to use `UpsertGlobalProperty` before the `client` has been initialised the `UpsertGlobalProperty` will just return, with no indication that the upsert has failed.

This PR always adds the upserted property to the `_globalProperties` property, and ensures it gets added when the client is initialised. 