### PR TITLE
Manually handle sending of crashes

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -75,10 +75,12 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
     }
 #elif NET8_0_OR_GREATER
+
     public ApplicationInsightsProvider()
     {
         // Do nothing. The net8.0 target exists for enabling unit testing, not for actual use.
     }
+
 #endif
 
     public static bool IsInitialized { get; private set; }
@@ -476,6 +478,11 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         try
         {
             if(Client is null)
+            {
+                return;
+            }
+
+            if(!IsTrackPageViewsEnabled)
             {
                 return;
             }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -23,7 +23,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public bool IsTrackErrorsEnabled { get; set; } = true;
     public bool IsTrackCrashesEnabled { get; set; } = true;
-    public bool HandleCrashes { get; set; } = true;
+    public bool IsTrackCrashesEnabled { get; set; } = true;
     public bool WriteCrashes { get; set; } = true;
     public bool IsTrackPageViewsEnabled { get; set; } = true;
     public bool IsAutoTrackPageViewsEnabled { get; set; } = true;
@@ -45,7 +45,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
-            if (HandleCrashes)
+            if (IsTrackCrashesEnabled)
             {
                 HandleCrash(e.Exception);
             }
@@ -53,7 +53,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            if (HandleCrashes)
+            if (IsTrackCrashesEnabled)
             {
                 HandleCrash((Exception)e.ExceptionObject);
             }
@@ -70,7 +70,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
         {
-            if (HandleCrashes)
+            if (IsTrackCrashesEnabled)
             {
                 HandleCrash(e.Exception);
             }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -43,7 +43,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
-            if (IsTrackCrashesEnabled)
+            if(IsTrackCrashesEnabled)
             {
                 HandleCrash(e.Exception);
             }
@@ -51,7 +51,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            if (IsTrackCrashesEnabled)
+            if(IsTrackCrashesEnabled)
             {
                 HandleCrash((Exception)e.ExceptionObject);
             }
@@ -87,14 +87,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         CreateTelemetryClient();
 
-        if (IsInitialized)
+        if(IsInitialized)
         {
             return;
         }
 
-        if (IsAutoTrackPageViewsEnabled)
+        if(IsAutoTrackPageViewsEnabled)
         {
-            if (Application.Current is null)
+            if(Application.Current is null)
             {
                 throw new NullReferenceException("Unable to configure `IsAutoTrackPageViewsEnabled` as `Application.Current` is null. You can either set `IsAutoTrackPageViewsEnabled` to false to ignore this issue, or check out this link for a possible reason - https://github.com/dhindrik/TinyInsights.Maui/issues/21");
             }
@@ -130,14 +130,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     private TelemetryClient? CreateTelemetryClient()
     {
-        if (client is not null)
+        if(client is not null)
         {
             return client;
         }
 
         try
         {
-            if (string.IsNullOrWhiteSpace(ConnectionString))
+            if(string.IsNullOrWhiteSpace(ConnectionString))
             {
                 throw new ArgumentNullException("ConnectionString", "ConnectionString is required to initialize TinyInsights");
             }
@@ -161,9 +161,38 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.Context.Component.Version = AppInfo.VersionString;
 
             // Add any global properties, the user has already added
-            foreach (var property in _globalProperties)
+            foreach(var property in _globalProperties)
             {
-                client.Context.GlobalProperties[property.Key] = property.Value;
+                switch(property.Key)
+                {
+                    case "Cloud.RoleName":
+                        client.Context.Cloud.RoleName = property.Value;
+                        break;
+
+                    case "Cloud.RoleInstance":
+                        client.Context.Cloud.RoleInstance = property.Value;
+                        break;
+
+                    case "Device.OperatingSystem":
+                        client.Context.Device.OperatingSystem = property.Value;
+                        break;
+
+                    case "Device.Model":
+                        client.Context.Device.Model = property.Value;
+                        break;
+
+                    case "Device.Type":
+                        client.Context.Device.Type = property.Value;
+                        break;
+
+                    case "Device.Id":
+                        client.Context.Device.Id = property.Value;
+                        break;
+
+                    default:
+                        client.Context.GlobalProperties[property.Key] = property.Value;
+                        break;
+                }
             }
 
             client.Context.GlobalProperties.TryAdd("Language", CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
@@ -173,12 +202,11 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.Context.GlobalProperties.TryAdd("OperatingSystemVersion", DeviceInfo.VersionString);
             client.Context.Session.Id = Guid.NewGuid().ToString();
 
-
             return client;
         }
-        catch (Exception)
+        catch(Exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Error creating TelemetryClient");
         }
 
@@ -187,53 +215,58 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void UpsertGlobalProperty(string key, string value)
     {
-        if (Client is null)
+        _globalProperties[key] = value;
+
+        if(Client is null)
         {
             return;
         }
 
-        switch (key)
+        switch(key)
         {
             case "Cloud.RoleName":
                 Client.Context.Cloud.RoleName = value;
-                return;
+                break;
+
             case "Cloud.RoleInstance":
                 Client.Context.Cloud.RoleInstance = value;
-                return;
+                break;
 
             case "Device.OperatingSystem":
                 Client.Context.Device.OperatingSystem = value;
-                return;
+                break;
+
             case "Device.Model":
                 Client.Context.Device.Model = value;
-                return;
+                break;
+
             case "Device.Type":
                 Client.Context.Device.Type = value;
-                return;
+                break;
+
             case "Device.Id":
                 Client.Context.Device.Id = value;
-                return;
+                break;
+
+            default:
+                Client.Context.GlobalProperties[key] = value;
+                break;
         }
-
-        _globalProperties[key] = value;
-
-        Client.Context.GlobalProperties[key] = value;
-
     }
 
     public void RemoveGlobalProperty(string key)
     {
-        if (Client is null)
+        if(Client is null)
         {
             return;
         }
 
-        if (_globalProperties.ContainsKey(key))
+        if(_globalProperties.ContainsKey(key))
         {
             _globalProperties.Remove(key);
         }
 
-        if (Client.Context.GlobalProperties.ContainsKey(key))
+        if(Client.Context.GlobalProperties.ContainsKey(key))
         {
             Client.Context.GlobalProperties.Remove(key);
         }
@@ -242,7 +275,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     public void OverrideAnonymousUserId(string userId)
     {
         Preferences.Set(userIdKey, userId);
-        if (Client is not null)
+        if(Client is not null)
         {
             Client.Context.User.Id = userId;
         }
@@ -265,7 +298,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void CreateNewSession()
     {
-        if (Client is null)
+        if(Client is null)
         {
             return;
         }
@@ -277,26 +310,26 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
             var crashes = ReadCrashes();
 
-            if (crashes is null || crashes.Count == 0)
+            if(crashes is null || crashes.Count == 0)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
 
-            foreach (var crash in crashes)
+            foreach(var crash in crashes)
             {
                 var ex = crash.GetException();
 
-                if (ex is null)
+                if(ex is null)
                 {
                     continue;
                 }
@@ -314,9 +347,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             ResetCrashes();
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error sending crashes. Message: {ex.Message}");
         }
     }
@@ -329,7 +362,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             var path = Path.Combine(logPath, crashLogFilename);
 
-            if (!File.Exists(path))
+            if(!File.Exists(path))
             {
                 return null;
             }
@@ -338,7 +371,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             return string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<List<Crash>>(json);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
             Trace.WriteLine($"TinyInsights: Error reading crashes. Message: {ex.Message}");
         }
@@ -350,15 +383,15 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Reset crashes");
 
             var path = Path.Combine(logPath, crashLogFilename);
             File.Delete(path);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error clearing crashes. Message: {ex.Message}");
         }
     }
@@ -367,7 +400,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Handle crashes");
 
             var crashes = ReadCrashes() ?? [];
@@ -380,9 +413,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             File.WriteAllText(path, json);
         }
-        catch (Exception exception)
+        catch(Exception exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error handling crashes. Message: {exception.Message}");
         }
     }
@@ -391,17 +424,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking error {ex.Message}");
 
             properties ??= [];
 
-            if (ex.StackTrace is not null)
+            if(ex.StackTrace is not null)
             {
                 properties.TryAdd("StackTrace", ex.StackTrace);
             }
@@ -409,9 +442,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackException(ex, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception exception)
+        catch(Exception exception)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking error. Message: {exception.Message}");
         }
     }
@@ -420,20 +453,20 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking event {eventName}");
 
             Client.TrackEvent(eventName, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking event. Message: {ex.Message}");
         }
     }
@@ -442,12 +475,12 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: tracking page view {viewName}");
 
             var pageView = new PageViewTelemetry(viewName)
@@ -472,9 +505,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking page view. Message: {ex.Message}");
         }
     }
@@ -483,17 +516,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if (Client is null)
+            if(Client is null)
             {
                 return;
             }
 
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking dependency {dependencyName}");
 
             var fullUrl = data;
 
-            if (data.Contains('?'))
+            if(data.Contains('?'))
             {
                 var split = data.Split("?");
                 data = split[0];
@@ -512,17 +545,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             dependency.Properties.Add("FullUrl", fullUrl);
 
-            if (httpMethod is not null)
+            if(httpMethod is not null)
             {
                 dependency.Properties.Add("HttpMethod", httpMethod.ToString());
             }
 
-            if (exception is not null)
+            if(exception is not null)
             {
                 dependency.Properties.Add("ExceptionMessage", exception.Message);
                 dependency.Properties.Add("StackTrace", exception.StackTrace);
 
-                if (exception.InnerException is not null)
+                if(exception.InnerException is not null)
                 {
                     dependency.Properties.Add("InnerExceptionMessage", exception.InnerException.Message);
                     dependency.Properties.Add("InnerExceptionStackTrace", exception.InnerException.StackTrace);
@@ -532,9 +565,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackDependency(dependency);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch (Exception ex)
+        catch(Exception ex)
         {
-            if (EnableConsoleLogging)
+            if(EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking dependency. Message: {ex.Message}");
         }
     }
@@ -548,7 +581,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public async void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (!IsEnabled(logLevel))
+        if(!IsEnabled(logLevel))
         {
             return;
         }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -409,7 +409,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         return null;
     }
 
-    private void ResetCrashes()
+    public void ResetCrashes()
     {
         try
         {

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -23,7 +23,6 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public bool IsTrackErrorsEnabled { get; set; } = true;
     public bool IsTrackCrashesEnabled { get; set; } = true;
-    public bool IsTrackCrashesEnabled { get; set; } = true;
     public bool WriteCrashes { get; set; } = true;
     public bool IsTrackPageViewsEnabled { get; set; } = true;
     public bool IsAutoTrackPageViewsEnabled { get; set; } = true;

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -45,7 +45,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
-            if(HandleCrashes)
+            if (HandleCrashes)
             {
                 HandleCrash(e.Exception);
             }
@@ -53,7 +53,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            if(HandleCrashes)
+            if (HandleCrashes)
             {
                 HandleCrash((Exception)e.ExceptionObject);
             }
@@ -77,12 +77,10 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
     }
 #elif NET8_0_OR_GREATER
-
     public ApplicationInsightsProvider()
     {
         // Do nothing. The net8.0 target exists for enabling unit testing, not for actual use.
     }
-
 #endif
 
     public static bool IsInitialized { get; private set; }
@@ -91,14 +89,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         CreateTelemetryClient();
 
-        if(IsInitialized)
+        if (IsInitialized)
         {
             return;
         }
 
-        if(IsAutoTrackPageViewsEnabled)
+        if (IsAutoTrackPageViewsEnabled)
         {
-            if(Application.Current is null)
+            if (Application.Current is null)
             {
                 throw new NullReferenceException("Unable to configure `IsAutoTrackPageViewsEnabled` as `Application.Current` is null. You can either set `IsAutoTrackPageViewsEnabled` to false to ignore this issue, or check out this link for a possible reason - https://github.com/dhindrik/TinyInsights.Maui/issues/21");
             }
@@ -110,10 +108,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Application.Current.PageDisappearing += weakOnDisappearingHandler.Handler;
         }
 
-        if(WriteCrashes)
-        {
-            Task.Run(SendCrashes);
-        }
+        Task.Run(SendCrashes);
 
         IsInitialized = true;
     }
@@ -137,14 +132,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     private TelemetryClient? CreateTelemetryClient()
     {
-        if(client is not null)
+        if (client is not null)
         {
             return client;
         }
 
         try
         {
-            if(string.IsNullOrWhiteSpace(ConnectionString))
+            if (string.IsNullOrWhiteSpace(ConnectionString))
             {
                 throw new ArgumentNullException("ConnectionString", "ConnectionString is required to initialize TinyInsights");
             }
@@ -168,7 +163,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             client.Context.Component.Version = AppInfo.VersionString;
 
             // Add any global properties, the user has already added
-            foreach(var property in _globalProperties)
+            foreach (var property in _globalProperties)
             {
                 switch(property.Key)
                 {
@@ -211,9 +206,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             return client;
         }
-        catch(Exception)
+        catch (Exception)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Error creating TelemetryClient");
         }
 
@@ -229,7 +224,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             return;
         }
 
-        switch(key)
+        switch (key)
         {
             case "Cloud.RoleName":
                 Client.Context.Cloud.RoleName = value;
@@ -263,17 +258,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void RemoveGlobalProperty(string key)
     {
-        if(Client is null)
+        if (Client is null)
         {
             return;
         }
 
-        if(_globalProperties.ContainsKey(key))
+        if (_globalProperties.ContainsKey(key))
         {
             _globalProperties.Remove(key);
         }
 
-        if(Client.Context.GlobalProperties.ContainsKey(key))
+        if (Client.Context.GlobalProperties.ContainsKey(key))
         {
             Client.Context.GlobalProperties.Remove(key);
         }
@@ -282,7 +277,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     public void OverrideAnonymousUserId(string userId)
     {
         Preferences.Set(userIdKey, userId);
-        if(Client is not null)
+        if (Client is not null)
         {
             Client.Context.User.Id = userId;
         }
@@ -305,7 +300,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public void CreateNewSession()
     {
-        if(Client is null)
+        if (Client is null)
         {
             return;
         }
@@ -317,26 +312,26 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(Client is null)
+            if (Client is null)
             {
                 return;
             }
 
             var crashes = ReadCrashes();
 
-            if(crashes is null || crashes.Count == 0)
+            if (crashes is null || crashes.Count == 0)
             {
                 return;
             }
 
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Sending {crashes.Count} crashes");
 
-            foreach(var crash in crashes)
+            foreach (var crash in crashes)
             {
                 var ex = crash.GetException();
 
-                if(ex is null)
+                if (ex is null)
                 {
                     continue;
                 }
@@ -354,9 +349,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             ResetCrashes();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error sending crashes. Message: {ex.Message}");
         }
     }
@@ -392,7 +387,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             var path = Path.Combine(logPath, crashLogFilename);
 
-            if(!File.Exists(path))
+            if (!File.Exists(path))
             {
                 return null;
             }
@@ -401,7 +396,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             return string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<List<Crash>>(json);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Trace.WriteLine($"TinyInsights: Error reading crashes. Message: {ex.Message}");
         }
@@ -413,15 +408,15 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Reset crashes");
 
             var path = Path.Combine(logPath, crashLogFilename);
             File.Delete(path);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error clearing crashes. Message: {ex.Message}");
         }
     }
@@ -430,7 +425,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine("TinyInsights: Handle crashes");
 
             var crashes = ReadCrashes() ?? [];
@@ -443,9 +438,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             File.WriteAllText(path, json);
         }
-        catch(Exception exception)
+        catch (Exception exception)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error handling crashes. Message: {exception.Message}");
         }
     }
@@ -454,17 +449,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(Client is null)
+            if (Client is null)
             {
                 return;
             }
 
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking error {ex.Message}");
 
             properties ??= [];
 
-            if(ex.StackTrace is not null)
+            if (ex.StackTrace is not null)
             {
                 properties.TryAdd("StackTrace", ex.StackTrace);
             }
@@ -472,9 +467,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackException(ex, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch(Exception exception)
+        catch (Exception exception)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking error. Message: {exception.Message}");
         }
     }
@@ -483,20 +478,20 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(Client is null)
+            if (Client is null)
             {
                 return;
             }
 
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking event {eventName}");
 
             Client.TrackEvent(eventName, properties);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking event. Message: {ex.Message}");
         }
     }
@@ -505,17 +500,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(Client is null)
+            if (Client is null)
             {
                 return;
             }
 
-            if(!IsTrackPageViewsEnabled)
+            if (!IsTrackPageViewsEnabled)
             {
                 return;
             }
 
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: tracking page view {viewName}");
 
             var pageView = new PageViewTelemetry(viewName)
@@ -540,9 +535,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking page view. Message: {ex.Message}");
         }
     }
@@ -551,17 +546,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         try
         {
-            if(Client is null)
+            if (Client is null)
             {
                 return;
             }
 
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking dependency {dependencyName}");
 
             var fullUrl = data;
 
-            if(data.Contains('?'))
+            if (data.Contains('?'))
             {
                 var split = data.Split("?");
                 data = split[0];
@@ -580,17 +575,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
             dependency.Properties.Add("FullUrl", fullUrl);
 
-            if(httpMethod is not null)
+            if (httpMethod is not null)
             {
                 dependency.Properties.Add("HttpMethod", httpMethod.ToString());
             }
 
-            if(exception is not null)
+            if (exception is not null)
             {
                 dependency.Properties.Add("ExceptionMessage", exception.Message);
                 dependency.Properties.Add("StackTrace", exception.StackTrace);
 
-                if(exception.InnerException is not null)
+                if (exception.InnerException is not null)
                 {
                     dependency.Properties.Add("InnerExceptionMessage", exception.InnerException.Message);
                     dependency.Properties.Add("InnerExceptionStackTrace", exception.InnerException.StackTrace);
@@ -600,9 +595,9 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Client.TrackDependency(dependency);
             await Client.FlushAsync(CancellationToken.None);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            if(EnableConsoleLogging)
+            if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Error tracking dependency. Message: {ex.Message}");
         }
     }
@@ -616,7 +611,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
     public async void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if(!IsEnabled(logLevel))
+        if (!IsEnabled(logLevel))
         {
             return;
         }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -107,7 +107,10 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             Application.Current.PageDisappearing += weakOnDisappearingHandler.Handler;
         }
 
-        Task.Run(SendCrashes);
+        if (WriteCrashes)
+        {
+            Task.Run(SendCrashes);
+        }
 
         IsInitialized = true;
     }

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -3,9 +3,11 @@ namespace TinyInsights;
 public interface IInsights
 {
     void AddProvider(IInsightsProvider provider);
+
     IReadOnlyList<IInsightsProvider> GetProviders();
 
     void UpsertGlobalProperty(string key, string value);
+
     void RemoveGlobalProperty(string key);
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
@@ -13,6 +15,7 @@ public interface IInsights
     Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, TimeSpan? duration = null);
 
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
+
     Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
@@ -25,5 +28,10 @@ public interface IInsights
     void OverrideAnonymousUserId(string userId);
 
     void GenerateNewAnonymousUserId();
+
     void CreateNewSession();
+
+    bool HasCrashed();
+
+    Task SendCrashes();
 }

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -34,4 +34,6 @@ public interface IInsights
     bool HasCrashed();
 
     Task SendCrashes();
+
+    void ResetCrashes();
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -37,4 +37,6 @@ public interface IInsightsProvider
     bool HasCrashed();
 
     Task SendCrashes();
+
+    void ResetCrashes();
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -3,7 +3,8 @@ namespace TinyInsights;
 public interface IInsightsProvider
 {
     bool IsTrackErrorsEnabled { get; set; }
-    public bool IsTrackCrashesEnabled { get; set; }
+    bool HandleCrashes { get; set; }
+    bool WriteCrashes { get; set; }
     bool IsTrackPageViewsEnabled { get; set; }
     bool IsAutoTrackPageViewsEnabled { get; set; }
     bool IsTrackEventsEnabled { get; set; }
@@ -14,6 +15,7 @@ public interface IInsightsProvider
     void Initialize();
 
     void UpsertGlobalProperty(string key, string value);
+
     void RemoveGlobalProperty(string key);
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
@@ -29,5 +31,10 @@ public interface IInsightsProvider
     void OverrideAnonymousUserId(string userId);
 
     string GenerateNewAnonymousUserId();
+
     void CreateNewSession();
+
+    bool HasCrashed();
+
+    Task SendCrashes();
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -3,7 +3,7 @@ namespace TinyInsights;
 public interface IInsightsProvider
 {
     bool IsTrackErrorsEnabled { get; set; }
-    bool HandleCrashes { get; set; }
+    bool IsTrackCrashesEnabled { get; set; }
     bool WriteCrashes { get; set; }
     bool IsTrackPageViewsEnabled { get; set; }
     bool IsAutoTrackPageViewsEnabled { get; set; }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -6,7 +6,7 @@ public class Insights : IInsights
 
     public void UpsertGlobalProperty(string key, string value)
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.UpsertGlobalProperty(key, value);
         }
@@ -14,7 +14,7 @@ public class Insights : IInsights
 
     public void RemoveGlobalProperty(string key)
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.RemoveGlobalProperty(key);
         }
@@ -39,14 +39,14 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        if(properties == null)
+        if (properties == null)
         {
             properties = new Dictionary<string, string>();
         }
 
         properties.TryAdd(nameof(ErrorSeverity), severity.ToString());
 
-        foreach(var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
+        foreach (var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
         {
             var task = provider.TrackErrorAsync(ex, properties);
             tasks.Add(task);
@@ -61,7 +61,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach(var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
+        foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
         {
             var task = provider.TrackPageViewAsync(viewName, properties, duration);
             tasks.Add(task);
@@ -75,7 +75,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach(var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
+        foreach (var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
         {
             var task = provider.TrackEventAsync(eventName, properties);
             tasks.Add(task);
@@ -97,7 +97,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach(var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
+        foreach (var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
         {
             if (provider.TrackDependencyFilter is not null && !provider.TrackDependencyFilter.Invoke((dependencyType, dependencyName, data, startTime, duration, success, resultCode, exception)))
             {
@@ -136,7 +136,7 @@ public class Insights : IInsights
 
     public void OverrideAnonymousUserId(string userId)
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.OverrideAnonymousUserId(userId);
         }
@@ -144,7 +144,7 @@ public class Insights : IInsights
 
     public void GenerateNewAnonymousUserId()
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.GenerateNewAnonymousUserId();
         }
@@ -152,7 +152,7 @@ public class Insights : IInsights
 
     public void CreateNewSession()
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.CreateNewSession();
         }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -6,7 +6,7 @@ public class Insights : IInsights
 
     public void UpsertGlobalProperty(string key, string value)
     {
-        foreach (var provider in insightsProviders)
+        foreach(var provider in insightsProviders)
         {
             provider.UpsertGlobalProperty(key, value);
         }
@@ -14,7 +14,7 @@ public class Insights : IInsights
 
     public void RemoveGlobalProperty(string key)
     {
-        foreach (var provider in insightsProviders)
+        foreach(var provider in insightsProviders)
         {
             provider.RemoveGlobalProperty(key);
         }
@@ -39,14 +39,14 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        if (properties == null)
+        if(properties == null)
         {
             properties = new Dictionary<string, string>();
         }
 
         properties.TryAdd(nameof(ErrorSeverity), severity.ToString());
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
         {
             var task = provider.TrackErrorAsync(ex, properties);
             tasks.Add(task);
@@ -61,7 +61,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
         {
             var task = provider.TrackPageViewAsync(viewName, properties, duration);
             tasks.Add(task);
@@ -75,7 +75,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
         {
             var task = provider.TrackEventAsync(eventName, properties);
             tasks.Add(task);
@@ -97,7 +97,7 @@ public class Insights : IInsights
     {
         var tasks = new List<Task>();
 
-        foreach (var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
+        foreach(var provider in insightsProviders.Where(x => x.IsTrackDependencyEnabled))
         {
             if (provider.TrackDependencyFilter is not null && !provider.TrackDependencyFilter.Invoke((dependencyType, dependencyName, data, startTime, duration, success, resultCode, exception)))
             {
@@ -136,7 +136,7 @@ public class Insights : IInsights
 
     public void OverrideAnonymousUserId(string userId)
     {
-        foreach (var provider in insightsProviders)
+        foreach(var provider in insightsProviders)
         {
             provider.OverrideAnonymousUserId(userId);
         }
@@ -144,7 +144,7 @@ public class Insights : IInsights
 
     public void GenerateNewAnonymousUserId()
     {
-        foreach (var provider in insightsProviders)
+        foreach(var provider in insightsProviders)
         {
             provider.GenerateNewAnonymousUserId();
         }
@@ -152,9 +152,31 @@ public class Insights : IInsights
 
     public void CreateNewSession()
     {
-        foreach (var provider in insightsProviders)
+        foreach(var provider in insightsProviders)
         {
             provider.CreateNewSession();
+        }
+    }
+
+    public bool HasCrashed()
+    {
+        foreach(var provider in insightsProviders)
+        {
+            bool hasCrashed = provider.HasCrashed();
+            if(hasCrashed)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public async Task SendCrashes()
+    {
+        foreach(var provider in insightsProviders)
+        {
+            await provider.SendCrashes();
         }
     }
 }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -179,4 +179,12 @@ public class Insights : IInsights
             await provider.SendCrashes();
         }
     }
+
+    public void ResetCrashes()
+    {
+        foreach(var provider in insightsProviders)
+        {
+            provider.ResetCrashes();
+        }
+    }
 }


### PR DESCRIPTION
Not sure if this is wanted or not, but we had a requirement that if the app crashed and the user has the analytics turned off, on the next launch, it would pop up saying the app crashed last time and then ask them if they want to enable analytics and send the report - 
![image](https://github.com/user-attachments/assets/15b2c08a-23b6-40e3-bd82-bbc90ef2ef86)
![image](https://github.com/user-attachments/assets/ccbffbd5-c421-4469-81b8-d3c82af96e09)

______________

To achieve this I added 3 new methods, so I can manually handle the sending of the crashes - 
- bool HasCrashed();
- Task SendCrashes();
- void ResetCrashes();

And added 1 new property to handle the writing/ sending of the crashes -

- bool WriteCrashes 
         - This can be defaulted to true to prevent a breaking change 
- bool HandleCrashes 
      - For some reason, I renamed `IsTrackCrashesEnabled` to `HandleCrashes`. This can be reverted to prevent a breaking change

______

What this allows me to do is have `HandleCrashes` _(IsTrackCrashesEnabled)_ always set to try regardless of the users settings. So that all crashes get written to a file. And have `WriteCrashes` set too false, and have my own logic to send the crashes

________

As long as the stuff mentioned above is done, there aren't any breaking changes.
