### PR TITLE
Track page visit duration

### DIFF
--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -526,12 +526,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             { "DisplayName", pageDisplayName },
         };
 
-        var metrics = new Dictionary<string, double>
-        {
-            { "Duration", pageVisitTime }
-        };
-
-        Client.TrackEvent("PageVisitTime", properties, metrics);
+        Client.TrackMetric("PageVisitTime", pageVisitTime, properties);
         await Client.FlushAsync(CancellationToken.None);
     }
 

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -519,16 +519,13 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         var properties = new Dictionary<string, string>
         {
-            { "PageUrl", pageFullName },
+            { "Page", pageFullName },
             { "DisplayName", pageDisplayName },
         };
 
         var metrics = new Dictionary<string, double>
         {
-            { "average", pageVisitTime },
-            { "max", pageVisitTime },
-            { "min", pageVisitTime },
-            { "sampleCount", 1 }
+            { "Duration", pageVisitTime }
         };
 
         Client.TrackEvent("PageVisitTime", properties, metrics);

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -139,7 +139,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
 
         var duration = DateTime.Now - lastPageAdded.Value.appearTime;
-        provider?.TrackPageVisitTime(pageType, duration.TotalMilliseconds);
+        provider?.TrackPageVisitTime(pageType.FullName ?? pageType.Name, pageType.Name, duration.TotalMilliseconds);
     }
 
     readonly Dictionary<string, string> _globalProperties = [];
@@ -510,7 +510,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
     }
 
-    public async Task TrackPageVisitTime(Type pageType, double pageVisitTime)
+    public async Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime)
     {
         if (Client is null)
         {
@@ -519,8 +519,8 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
 
         var properties = new Dictionary<string, string>
         {
-            { "PageUrl", pageType.FullName ?? pageType.Name },
-            { "DisplayName", pageType.Name },
+            { "PageUrl", pageFullName },
+            { "DisplayName", pageDisplayName },
         };
 
         var metrics = new Dictionary<string, double>

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -131,14 +131,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         var pageType = e.GetType();
 
-        (Type pageType, DateTime appearTime)? lastPageAdded = _pageVisitTimeTracking.LastOrDefault(x => x.pageType == pageType);
+        var lastIndex = _pageVisitTimeTracking.FindLastIndex(x => x.pageType == pageType);
 
-        if (lastPageAdded is null)
+        if (lastIndex == -1)
         {
             return;
         }
 
-        var duration = DateTime.Now - lastPageAdded.Value.appearTime;
+        var lastPageAdded = _pageVisitTimeTracking[lastIndex];
+        _pageVisitTimeTracking.RemoveAt(lastIndex);
+
+        var duration = DateTime.Now - lastPageAdded.appearTime;
         provider?.TrackPageVisitTime(pageType.FullName ?? pageType.Name, pageType.Name, duration.TotalMilliseconds);
     }
 

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -12,7 +12,9 @@ public interface IInsights
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, TimeSpan? duration = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);
+
+    Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
 

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -22,6 +22,8 @@ public interface IInsightsProvider
 
     Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, TimeSpan? duration = null);
 
+    Task TrackPageVisitTime(Type pageType, double pageVisitTime);
+
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, HttpMethod? httpMethod, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -20,9 +20,13 @@ public interface IInsightsProvider
 
     Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, TimeSpan? duration = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);
 
-    Task TrackPageVisitTime(Type pageType, double pageVisitTime);
+    /// <summary>
+    /// Track the duration a user spent on a page
+    /// </summary>
+    /// <param name="pageVisitTime">Duration in milliseconds</param>
+    Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
     Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
 

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -57,13 +57,27 @@ public class Insights : IInsights
         return Task.CompletedTask;
     }
 
-    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, TimeSpan? duration = null)
+    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null)
     {
         var tasks = new List<Task>();
 
         foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
         {
-            var task = provider.TrackPageViewAsync(viewName, properties, duration);
+            var task = provider.TrackPageViewAsync(viewName, properties);
+            tasks.Add(task);
+        }
+
+        _ = Task.WhenAll(tasks);
+        return Task.CompletedTask;
+    }
+
+    public Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime)
+    {
+        var tasks = new List<Task>();
+
+        foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
+        {
+            var task = provider.TrackPageVisitTime(pageFullName, pageDisplayName, pageVisitTime);
             tasks.Add(task);
         }
 
@@ -160,10 +174,10 @@ public class Insights : IInsights
 
     public bool HasCrashed()
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             bool hasCrashed = provider.HasCrashed();
-            if(hasCrashed)
+            if (hasCrashed)
             {
                 return true;
             }
@@ -174,7 +188,7 @@ public class Insights : IInsights
 
     public async Task SendCrashes()
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             await provider.SendCrashes();
         }
@@ -182,7 +196,7 @@ public class Insights : IInsights
 
     public void ResetCrashes()
     {
-        foreach(var provider in insightsProviders)
+        foreach (var provider in insightsProviders)
         {
             provider.ResetCrashes();
         }


### PR DESCRIPTION
A New custom event called `PageVisitTime` was added, with custom metrics added for the `Duration` in milliseconds.

In application insights, the new event looks like this -
![image](https://github.com/user-attachments/assets/2068b274-a62c-4b0d-a2f4-f8a750bca4d9)


This fixes the timeline history of events, `Page View` is tracked as the page loads and `PageVisitTime` is tracked as the user leaves the page -
![image](https://github.com/user-attachments/assets/0d2e09da-1250-4791-82a2-2fc245c61556)

#48 

