### PR TITLE
[implementation] decompose ApplicationInsightsProvider into azure ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ builder.UseMauiInsights("{YOUR_CONNECTION_STRING}",
         });
 ```
 
+The package comes with a default implementation of a crash handler that stores crash data in a json file before application is terminated.
+On the next application run the data will be deserialized from the json file and submitted to Azure Insights.
+You can also replace it by your own implementation of `ICrashHandler` interface:
+```csharp
+.UseTinyInsights("{YOUR_CONNECTION_STRING}", (provider) =>
+	{            
+		provider.SetCrashHandler(MyOwnCrashHandler);
+	});
+```
+
 ### Track events
 Crashes will be tracked automatically if it is enabled, other events you need to track manually. 
 

--- a/TinyInsights.TestApp/App.xaml.cs
+++ b/TinyInsights.TestApp/App.xaml.cs
@@ -28,11 +28,11 @@ public partial class App : Application
         return new Window(shell);
     }
 
-    protected override void OnSleep()
+    protected async override void OnSleep()
     {
         base.OnSleep();
 
         var insights = serviceProvider.GetRequiredService<IInsights>();
-        insights.FlushAsync().Wait();
+        await insights.FlushAsync();
     }
 }

--- a/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
+++ b/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace TinyInsights.CrashHandlers;
+
+public class CrashToJsonFileStorageHandler : ICrashHandler
+{	
+	private const string crashLogFilename = "crashes.mauiinsights";
+
+	private string crashStorageFilePath => Path.Combine(FileSystem.CacheDirectory, crashLogFilename);
+
+	public bool HasCrashed()
+	{
+		try
+		{
+			return File.Exists(crashStorageFilePath);
+		}
+		catch (Exception ex)
+		{
+			Trace.WriteLine($"TinyInsights: Error on {nameof(HasCrashed)}. Message: {ex.Message}");
+			return false;
+		}
+	}
+
+	public void PushCrashToStorage(Exception ex)
+	{
+		try
+		{
+			Trace.WriteLine("TinyInsights: Handle crashes");
+
+			var crashes = ReadCrashes() ?? [];
+
+			crashes.Add(new Crash(ex));
+
+			var json = JsonSerializer.Serialize(crashes);
+
+			File.WriteAllText(crashStorageFilePath, json);
+		}
+		catch (Exception exception)
+		{
+			Trace.WriteLine($"TinyInsights: Error on {nameof(PushCrashToStorage)}. Message: {exception.Message}");
+		}
+	}
+
+	public List<Crash>? PopCrashesFromStorage()
+	{
+		List<Crash>? crashes = ReadCrashes();
+		if (crashes is null)
+		{
+			return null;
+		}
+		
+		EraseCrashes();
+
+		return crashes;
+	}
+
+	private void EraseCrashes()
+	{
+		try
+		{
+			Trace.WriteLine($"TinyInsights: {nameof(EraseCrashes)}");
+
+			File.Delete(crashStorageFilePath);
+		}
+		catch (Exception ex)
+		{
+			Trace.WriteLine($"TinyInsights: Error on {nameof(EraseCrashes)}. Message: {ex.Message}");
+		}
+	}
+
+	private List<Crash>? ReadCrashes()
+	{
+		try
+		{
+			Trace.WriteLine("TinyInsights: Read crashes");
+			
+			if (!File.Exists(crashStorageFilePath))
+			{
+				return null;
+			}
+
+			var json = File.ReadAllText(crashStorageFilePath);
+
+			return string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<List<Crash>>(json);
+		}
+		catch (Exception ex)
+		{
+			Trace.WriteLine($"TinyInsights: Error reading crashes. Message: {ex.Message}");
+		}
+
+		return null;
+	}
+}

--- a/TinyInsights/CrashHandlers/ICrashHandler.cs
+++ b/TinyInsights/CrashHandlers/ICrashHandler.cs
@@ -1,0 +1,24 @@
+﻿namespace TinyInsights.CrashHandlers;
+
+/// <summary>
+/// Crash handler for unhandled exceptions.
+/// </summary>
+public interface ICrashHandler
+{
+	/// <summary>
+	/// Indicates if the app has crashed on the app previous run.
+	/// There are some crash data stored in the underlying storage.
+	/// </summary>	
+	bool HasCrashed();
+
+	/// <summary>
+	/// Reads and removes the crash data from the underlying storage and returns a list of crashes.
+	/// </summary>
+	List<Crash>? PopCrashesFromStorage();
+
+	/// <summary>
+	/// Pushes the unhandled exception. 
+	/// This method is supposed to be called when the app crashes in order to store the crash information in the underlying storage.
+	/// </summary>	
+	void PushCrashToStorage(Exception ex);
+}

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -31,11 +31,5 @@ public interface IInsights
 
     void CreateNewSession();
 
-    bool HasCrashed();
-
-    Task SendCrashes();
-
-    void ResetCrashes();
-
     Task FlushAsync();
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -1,3 +1,5 @@
+using TinyInsights.CrashHandlers;
+
 namespace TinyInsights;
 
 public interface IInsightsProvider
@@ -34,10 +36,7 @@ public interface IInsightsProvider
 
     void CreateNewSession();
 
-    bool HasCrashed();
-
-    Task SendCrashes();
-
-    void ResetCrashes();
     Task FlushAsync();
+
+	void SetCrashHandler(ICrashHandler customCrashHandler);
 }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace TinyInsights;
 
 public class Insights : IInsights
@@ -155,36 +157,6 @@ public class Insights : IInsights
         foreach (var provider in insightsProviders)
         {
             provider.CreateNewSession();
-        }
-    }
-
-    public bool HasCrashed()
-    {
-        foreach (var provider in insightsProviders)
-        {
-            bool hasCrashed = provider.HasCrashed();
-            if (hasCrashed)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public async Task SendCrashes()
-    {
-        foreach (var provider in insightsProviders)
-        {
-            await provider.SendCrashes();
-        }
-    }
-
-    public void ResetCrashes()
-    {
-        foreach (var provider in insightsProviders)
-        {
-            provider.ResetCrashes();
         }
     }
 

--- a/TinyInsights/TinyInsights.csproj
+++ b/TinyInsights/TinyInsights.csproj
@@ -31,13 +31,13 @@
     </ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8')) ">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100"/>
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100"/>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('net9')) ">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10"/>
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.10"/>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.10" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
Decompose `ApplicationInsightsProvider` into azure insights interactions and crash storage logic (moved to `CrashToJsonFileStorageHandler`). The logic better belong to a separate service and the library users be able to override it with their own.

**Note**: 
- it directs merge back to feature branch in-progress `flush` that I forked off the branch from

- it's mostly refactoring only, however, there is one place where I decided to change the logic:
[here](https://github.com/dhindrik/TinyInsights.Maui/pull/59/files#diff-ecd970c3caa302b00f795e18fbf4853ccfb73b41467a0653f03899219d90a1f1L337) - I decided to replace 
`1) Read Crash 2) Send Crash to Insights 3) Delete Crash`  
by 
`1) Read Crash 2) Delete Crash 3) Send Crash to Insights`. 
`PopCrashesFromStorage` does exactly that: reads crash information and erases it before returning back. Otherwise app is at risk of never being able to send the crush repot and clean the file if failing on the `2) Send Crash to Insights` step. I feel like it's a bit risky. Choosing between 2 risks, I'd say it's better to lose the crash report than being at risk of stuck in growing json file with no way to delete it.

## Testing
Tested it by running TinyInsights Maui test map and clicking couple of battens, imitating unhandled exception few time

Then under debugger watched `SendCrashes` execution step by step and checked my Azure Insights
![image](https://github.com/user-attachments/assets/fea3a8c2-a8ce-409a-85e1-00d9af0c7ffe)

