### PR TITLE
Naming conventions added to editorconfig, for code consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -53,10 +53,5 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style._fieldname.required_prefix =
-dotnet_naming_style._fieldname.required_suffix = 
-dotnet_naming_style._fieldname.word_separator = 
-dotnet_naming_style._fieldname.capitalization = camel_case
-
 # Make whitespace violations warnings
 dotnet_diagnostic.IDE0055.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,57 @@ root = true
 [*.cs]
 indent_style = space
 indent_size = 4
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = error
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.severity = error
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be__fieldname.style = _fieldname
+
+# Naming symbols
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, enum, delegate
+
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, method, event
+
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = private, internal
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style._fieldname.required_prefix =
+dotnet_naming_style._fieldname.required_suffix = 
+dotnet_naming_style._fieldname.word_separator = 
+dotnet_naming_style._fieldname.capitalization = camel_case

--- a/.editorconfig
+++ b/.editorconfig
@@ -53,5 +53,10 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
+dotnet_naming_style.camel_case.required_prefix = 
+dotnet_naming_style.camel_case.required_suffix = 
+dotnet_naming_style.camel_case.word_separator = 
+dotnet_naming_style.camel_case.capitalization = camel_case
+
 # Make whitespace violations warnings
 dotnet_diagnostic.IDE0055.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,9 +22,9 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.severity = error
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.symbols = private_or_internal_field
-dotnet_naming_rule.private_or_internal_field_should_be__fieldname.style = _fieldname
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = error
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
 
 # Naming symbols
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -57,3 +57,6 @@ dotnet_naming_style._fieldname.required_prefix =
 dotnet_naming_style._fieldname.required_suffix = 
 dotnet_naming_style._fieldname.word_separator = 
 dotnet_naming_style._fieldname.capitalization = camel_case
+
+# Make whitespace violations warnings
+dotnet_diagnostic.IDE0055.severity = warning

--- a/TinyInsights.TestApp/NewPage.xaml.cs
+++ b/TinyInsights.TestApp/NewPage.xaml.cs
@@ -4,11 +4,11 @@ namespace TinyInsights.TestApp;
 
 public partial class NewPage : ContentPage
 {
-	public NewPage()
-	{
-		InitializeComponent();
+    public NewPage()
+    {
+        InitializeComponent();
 
-        Appearing += (_,_) =>
+        Appearing += (_, _) =>
         {
             Debug.WriteLine("NewPage Appearing event");
         };
@@ -23,6 +23,6 @@ public partial class NewPage : ContentPage
 
     private async void Button_Clicked(object sender, EventArgs e)
     {
-		await Navigation.PushAsync(new NewPage1());
+        await Navigation.PushAsync(new NewPage1());
     }
 }

--- a/TinyInsights.TestApp/NewPage1.xaml.cs
+++ b/TinyInsights.TestApp/NewPage1.xaml.cs
@@ -2,8 +2,8 @@ namespace TinyInsights.TestApp;
 
 public partial class NewPage1 : ContentPage
 {
-	public NewPage1()
-	{
-		InitializeComponent();
-	}
+    public NewPage1()
+    {
+        InitializeComponent();
+    }
 }

--- a/TinyInsights.Web/Services/Models/ErrorItem.cs
+++ b/TinyInsights.Web/Services/Models/ErrorItem.cs
@@ -12,24 +12,24 @@ public class ErrorItem : LogItem
     public string? ClientType => GetData("client_Type");
     public string? ClientModel => GetData("client_Model");
     public string? ClientOs => GetData("client_OS");
-    public string? ClientOsVersion 
-    { 
+    public string? ClientOsVersion
+    {
         get
         {
-            var os = GetData("OperatingSystemVersion"); 
-            
-            if(os!= null)
+            var os = GetData("OperatingSystemVersion");
+
+            if (os != null)
             {
                 return os;
             }
-            
+
             // For android it can be forexample Android 14.
             var browser = GetData("client_Browser");
-            
-            if(browser != null)
+
+            if (browser != null)
             {
                 var split = browser.Split(" ");
-                if(split.Length > 1 && double.TryParse(split[1], out var version))
+                if (split.Length > 1 && double.TryParse(split[1], out var version))
                 {
                     return version.ToString();
                 }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -76,7 +76,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         ConnectionString = connectionString;
         provider = this;
-        
+
         this.crashHandler = crashHandler ?? CreateDefaultCrashHandlerType();
 
         app.UnhandledException += App_UnhandledException;

--- a/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
+++ b/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
@@ -9,7 +9,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
 
     private string CrashStorageFilePath => Path.Combine(FileSystem.CacheDirectory, CrashLogFilename);
 
-    public bool HasCrashed()
+    public virtual bool HasCrashed()
     {
         try
         {
@@ -22,7 +22,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         }
     }
 
-    public void PushCrashToStorage(Exception ex)
+    public virtual void PushCrashToStorage(Exception ex)
     {
         try
         {
@@ -42,7 +42,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         }
     }
 
-    public List<Crash>? PopCrashesFromStorage()
+    public virtual List<Crash>? PopCrashesFromStorage()
     {
         List<Crash>? crashes = ReadCrashes();
         if (crashes is null)
@@ -55,7 +55,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         return crashes;
     }
 
-    public void EraseCrashes()
+    public virtual void EraseCrashes()
     {
         try
         {
@@ -69,7 +69,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         }
     }
 
-    private List<Crash>? ReadCrashes()
+    protected virtual List<Crash>? ReadCrashes()
     {
         try
         {

--- a/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
+++ b/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
@@ -5,15 +5,15 @@ namespace TinyInsights.CrashHandlers;
 
 public class CrashToJsonFileStorageHandler : ICrashHandler
 {    
-    private const string crashLogFilename = "crashes.mauiinsights";
+    private const string CrashLogFilename = "crashes.mauiinsights";
 
-    private string crashStorageFilePath => Path.Combine(FileSystem.CacheDirectory, crashLogFilename);
+    private string CrashStorageFilePath => Path.Combine(FileSystem.CacheDirectory, CrashLogFilename);
 
     public bool HasCrashed()
     {
         try
         {
-            return File.Exists(crashStorageFilePath);
+            return File.Exists(CrashStorageFilePath);
         }
         catch (Exception ex)
         {
@@ -34,7 +34,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
 
             var json = JsonSerializer.Serialize(crashes);
 
-            File.WriteAllText(crashStorageFilePath, json);
+            File.WriteAllText(CrashStorageFilePath, json);
         }
         catch (Exception exception)
         {
@@ -61,7 +61,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         {
             Trace.WriteLine($"TinyInsights: {nameof(EraseCrashes)}");
 
-            File.Delete(crashStorageFilePath);
+            File.Delete(CrashStorageFilePath);
         }
         catch (Exception ex)
         {
@@ -75,12 +75,12 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         {
             Trace.WriteLine("TinyInsights: Read crashes");
             
-            if (!File.Exists(crashStorageFilePath))
+            if (!File.Exists(CrashStorageFilePath))
             {
                 return null;
             }
 
-            var json = File.ReadAllText(crashStorageFilePath);
+            var json = File.ReadAllText(CrashStorageFilePath);
 
             return string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<List<Crash>>(json);
         }

--- a/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
+++ b/TinyInsights/CrashHandlers/CrashToJsonFileStorageHandler.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace TinyInsights.CrashHandlers;
 
 public class CrashToJsonFileStorageHandler : ICrashHandler
-{    
+{
     private const string CrashLogFilename = "crashes.mauiinsights";
 
     private string CrashStorageFilePath => Path.Combine(FileSystem.CacheDirectory, CrashLogFilename);
@@ -49,7 +49,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         {
             return null;
         }
-        
+
         EraseCrashes();
 
         return crashes;
@@ -74,7 +74,7 @@ public class CrashToJsonFileStorageHandler : ICrashHandler
         try
         {
             Trace.WriteLine("TinyInsights: Read crashes");
-            
+
             if (!File.Exists(CrashStorageFilePath))
             {
                 return null;

--- a/TinyInsights/Dependency.cs
+++ b/TinyInsights/Dependency.cs
@@ -40,7 +40,7 @@ public class Dependency : IDisposable
     {
         await semaphore.WaitAsync();
 
-        if(!isFinished)
+        if (!isFinished)
         {
             Duration = DateTimeOffset.Now - StartTime;
 

--- a/TinyInsights/TinyInsights.csproj
+++ b/TinyInsights/TinyInsights.csproj
@@ -42,4 +42,7 @@
 	<ItemGroup>
 		<None Include="readme.txt" pack="true" PackagePath="." />
 	</ItemGroup>
+	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+	  <Exec Command="dotnet format --verify-no-changes" />
+	</Target>
 </Project>

--- a/TinyInsights/TinyInsights.csproj
+++ b/TinyInsights/TinyInsights.csproj
@@ -42,7 +42,4 @@
 	<ItemGroup>
 		<None Include="readme.txt" pack="true" PackagePath="." />
 	</ItemGroup>
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-	  <Exec Command="dotnet format --verify-no-changes" />
-	</Target>
 </Project>


### PR DESCRIPTION
Goal: all contributors to follow certain naming rules so the code looks consistent across the solution.

- naming style rules added to .editorconfig
- some code is fixed as per these conventions
- methods made virtual in `CrashToJsonFileStorageHandler`

I'd advise to add the job to github yml file to enforce the rule in ci/cd
```
      - name: Run dotnet format
        run: dotnet format --verify-no-changes
```