### PR TITLE
"Throw task unobserved exception" imitation button added

### DIFF
--- a/TinyInsights.TestApp/MainPage.xaml
+++ b/TinyInsights.TestApp/MainPage.xaml
@@ -38,6 +38,11 @@
                 Clicked="CustomCrashButton_Clicked"
                 Text="Crash app with custom exception" />
 
+            <Button
+                x:Name="CrashWithUnobservedExceptionButton"
+                Clicked="CrashWithUnobservedExceptionButton_OnClicked"
+                Text="Throw task unobserved exception" />
+            
             <Button Clicked="NewPageButton_Clicked" Text="Test page automatic page tracking" />
 
             <Button Clicked="Button_Clicked" Text="clear gc" />

--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -107,4 +107,14 @@ public partial class MainPage : ContentPage
     {
         throw new CustomException();
     }
+
+    private void CrashWithUnobservedExceptionButton_OnClicked(object sender, EventArgs e)
+    {
+        Task.Run(() =>
+        {
+            throw new Exception("Unobserved exception text");
+        });
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
 }


### PR DESCRIPTION
2 "Crash app" buttons imitate exceptions in the main UI thread, which is caught by `AppDomain.CurrentDomain.UnhandledException`. Since `ApplicationInsightsProvider` catches `TaskScheduler.UnobservedTaskException` as well we need a way to test it. New button in the TestApp throws exception that just right that. 

Tested by setting breakpoint inside `CurrentDomain_UnhandledException` and making sure it's hit