### PR TITLE
[implementation] Deferred connect to Application Insights implemented

### DIFF
--- a/TinyInsights.TestApp/MainPage.xaml
+++ b/TinyInsights.TestApp/MainPage.xaml
@@ -46,6 +46,9 @@
             <Button Clicked="NewPageButton_Clicked" Text="Test page automatic page tracking" />
 
             <Button Clicked="Button_Clicked" Text="clear gc" />
+
+            <Button Clicked="ConnectRetryButton_Clicked" Text="Simulate deferred connect" />
+
         </VerticalStackLayout>
     </ScrollView>
 

--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -117,4 +117,11 @@ public partial class MainPage : ContentPage
         GC.Collect();
         GC.WaitForPendingFinalizers();
     }
+
+    private async void ConnectRetryButton_Clicked(object sender, EventArgs e)
+    {
+        bool wereAllInitialized = insights.AreAllProvidersInitialized;
+        bool becameAllInitialized = insights.Connect("InstrumentationKey=8b51208f-7926-4b7b-9867-16989206b950;IngestionEndpoint=https://swedencentral-0.in.applicationinsights.azure.com/;ApplicationId=0c04d3a0-9ee2-41a5-996e-526552dc730f");
+        await DisplayAlert("Result", $"Were all initialized (before the call): {wereAllInitialized}, became all initialized: {becameAllInitialized}", "Ok");
+    }
 }

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -169,7 +169,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         crashHandler = customCrashHandler;
     }
-   
+
     public void Connect(string connectionString)
     {
         ArgumentNullException.ThrowIfNull(connectionString);

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -54,6 +54,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     public bool IsTrackEventsEnabled { get; set; } = true;
     public bool IsTrackDependencyEnabled { get; set; } = true;
     public bool EnableConsoleLogging { get; set; }
+    public bool IsTelemetryClientInitialized => client is not null;
 
     private static ICrashHandler CreateDefaultCrashHandlerType() => new CrashToJsonFileStorageHandler();
 
@@ -168,7 +169,17 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
     {
         crashHandler = customCrashHandler;
     }
+   
+    public void Connect(string connectionString)
+    {
+        ArgumentNullException.ThrowIfNull(connectionString);
 
+        if (!IsTelemetryClientInitialized)
+        {
+            ConnectionString = connectionString;
+            CreateTelemetryClient();
+        }
+    }
 
     private static void OnAppearing(object? sender, Page e)
     {
@@ -209,7 +220,8 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         {
             if (string.IsNullOrWhiteSpace(ConnectionString))
             {
-                throw new ArgumentNullException("ConnectionString", "ConnectionString is required to initialize TinyInsights");
+                Console.WriteLine("ConnectionString is required to initialize TinyInsights");
+                return null;
             }
 
             configuration = new TelemetryConfiguration()

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -40,4 +40,17 @@ public interface IInsights
     void ResetCrashes();
 
     Task FlushAsync();
+
+    /// <summary>
+    /// Indicates whether all providers have been successfully initialized.
+    /// </summary>
+    bool AreAllProvidersInitialized { get; }
+
+    /// <summary>
+    /// Connects to Application Insights using the provided connection string.
+    /// Applied only to providers not yet initialized.
+    /// </summary>
+    /// <param name="applicationInsightsConnectionString">Connection string to initialize providers with</param>
+    /// <returns>True if all providers are initialized once operation is executed</returns>
+    bool Connect(string applicationInsightsConnectionString);
 }

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -50,4 +50,12 @@ public interface IInsightsProvider
     Task FlushAsync();
 
     void SetCrashHandler(ICrashHandler customCrashHandler);
+
+    bool IsTelemetryClientInitialized { get; }
+
+    /// <summary>
+    /// Connects the provider's telemetry client to Application Insights service using the provided connection string.
+    /// If telemetry client is already initialized, this method will do nothing.
+    /// </summary> 
+    void Connect(string connectionString);
 }

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -25,6 +25,18 @@ public class Insights : IInsights
         insightsProviders.Add(provider);
     }
 
+    public bool Connect(string applicationInsightsConnectionString)
+    {
+        foreach (IInsightsProvider provider in insightsProviders.Where(p => !p.IsTelemetryClientInitialized))
+        {
+            provider.Connect(applicationInsightsConnectionString);
+        }
+
+        return AreAllProvidersInitialized;
+    }
+
+    public bool AreAllProvidersInitialized => insightsProviders.All(p => p.IsTelemetryClientInitialized);
+
     public IReadOnlyList<IInsightsProvider> GetProviders()
     {
         return insightsProviders;


### PR DESCRIPTION
### Motivation
The PR creates compensatory mechanism for cases when connection string was not available at the time of the application startup, or available but for some reason telemetry client initialization crashed in the middle. 

Practical specific case: some apps do not come with Application Insights connection string in the package, it's retrieved dynamically from the cloud. Then deferred connect to Application Insights is needed whenever the string becomes available

### Testing
Just for testing purposes I set connection string to `null` inside `UseTinyInsights( ...)` declaration of the TestApp, then ran it, clicked different buttons to make sure nothing crashes with non-initialized telemetry client. Then clicked new "Simulate deferred connect", debugged step by step to make sure code is executed as expected. After that checked my Azure Insights to make sure it starts receiving new events and pageviews

First click/Second click
<p>
<img src="https://github.com/user-attachments/assets/7e63d892-858c-4dc3-8e6e-da14f73efe3d" width="300">​
<img src="https://github.com/user-attachments/assets/320ccf26-c6b4-4b83-a4c3-7718a3e897ec" width="300">​
</p>

Application Insights

<img src="https://github.com/user-attachments/assets/158b3a58-6f59-468f-a490-ad98b480b8bc" width="600">

