### PR TITLE
Add optional metrics tracking to events, exceptions and page view

### DIFF
--- a/TinyInsights.TestApp/MainPage.xaml.cs
+++ b/TinyInsights.TestApp/MainPage.xaml.cs
@@ -57,7 +57,14 @@ public partial class MainPage : ContentPage
             return;
         }
 
-        await insights.TrackEventAsync("EventButton");
+        var metrics = new Dictionary<string, double>()
+        {
+            {"metric1", 1.0},
+            {"metric2", 2.0}
+        };
+
+
+        await insights.TrackEventAsync("EventButton", metrics: metrics);
     }
 
     private async void ExceptionButton_OnClicked(object? sender, EventArgs e)

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -461,7 +461,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         crashHandler.EraseCrashes();
     }
 
-    public async Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public async Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         try
         {
@@ -489,7 +489,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
     }
 
-    public async Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public async Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         try
         {
@@ -527,7 +527,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         await Client.FlushAsync(CancellationToken.None);
     }
 
-    public async Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public async Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         try
         {

--- a/TinyInsights/ApplicationInsightsProvider.cs
+++ b/TinyInsights/ApplicationInsightsProvider.cs
@@ -461,7 +461,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         crashHandler.EraseCrashes();
     }
 
-    public async Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null)
+    public async Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         try
         {
@@ -480,7 +480,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
                 properties.TryAdd("StackTrace", ex.StackTrace);
             }
 
-            Client.TrackException(ex, properties);
+            Client.TrackException(ex, properties, metrics);
         }
         catch (Exception exception)
         {
@@ -489,7 +489,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         }
     }
 
-    public async Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null)
+    public async Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         try
         {
@@ -501,7 +501,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
             if (EnableConsoleLogging)
                 Console.WriteLine($"TinyInsights: Tracking event {eventName}");
 
-            Client.TrackEvent(eventName, properties);
+            Client.TrackEvent(eventName, properties, metrics);
         }
         catch (Exception ex)
         {
@@ -527,7 +527,7 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
         await Client.FlushAsync(CancellationToken.None);
     }
 
-    public async Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null)
+    public async Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         try
         {
@@ -554,6 +554,14 @@ public class ApplicationInsightsProvider : IInsightsProvider, ILogger
                 foreach (var property in properties)
                 {
                     pageView.Properties.Add(property.Key, property.Value);
+                }
+            }
+
+            if (metrics is not null)
+            {
+                foreach (var metric in metrics)
+                {
+                    pageView.Metrics.Add(metric.Key, metric.Value);
                 }
             }
 

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -10,15 +10,15 @@ public interface IInsights
 
     void RemoveGlobalProperty(string key);
 
-    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
+    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
     Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
-    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
+    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
-    Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null);
+    Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
 

--- a/TinyInsights/IInsights.cs
+++ b/TinyInsights/IInsights.cs
@@ -10,15 +10,15 @@ public interface IInsights
 
     void RemoveGlobalProperty(string key);
 
-    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
     Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
-    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
-    Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
 

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -20,9 +20,9 @@ public interface IInsightsProvider
 
     void RemoveGlobalProperty(string key);
 
-    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
     /// <summary>
     /// Track the duration a user spent on a page
@@ -30,7 +30,7 @@ public interface IInsightsProvider
     /// <param name="pageVisitTime">Duration in milliseconds</param>
     Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
-    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
+    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, HttpMethod? httpMethod, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
 

--- a/TinyInsights/IInsightsProvider.cs
+++ b/TinyInsights/IInsightsProvider.cs
@@ -20,9 +20,9 @@ public interface IInsightsProvider
 
     void RemoveGlobalProperty(string key);
 
-    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null);
+    Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
-    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null);
+    Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
     /// <summary>
     /// Track the duration a user spent on a page
@@ -30,7 +30,7 @@ public interface IInsightsProvider
     /// <param name="pageVisitTime">Duration in milliseconds</param>
     Task TrackPageVisitTime(string pageFullName, string pageDisplayName, double pageVisitTime);
 
-    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null);
+    Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null);
 
     Task TrackDependencyAsync(string dependencyType, string dependencyName, string data, HttpMethod? httpMethod, DateTimeOffset startTime, TimeSpan duration, bool success, int resultCode = 0, Exception? exception = null);
 

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -42,12 +42,12 @@ public class Insights : IInsights
         return insightsProviders;
     }
 
-    public Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null)
+    public Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
-        return TrackErrorAsync(ex, ErrorSeverity.Default, properties);
+        return TrackErrorAsync(ex, ErrorSeverity.Default, properties, metrics);
     }
 
-    public Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null)
+    public Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 
@@ -60,7 +60,7 @@ public class Insights : IInsights
 
         foreach (var provider in insightsProviders.Where(x => x.IsTrackErrorsEnabled))
         {
-            var task = provider.TrackErrorAsync(ex, properties);
+            var task = provider.TrackErrorAsync(ex, properties, metrics);
             tasks.Add(task);
         }
 
@@ -69,13 +69,13 @@ public class Insights : IInsights
         return Task.CompletedTask;
     }
 
-    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null)
+    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 
         foreach (var provider in insightsProviders.Where(x => x.IsTrackPageViewsEnabled))
         {
-            var task = provider.TrackPageViewAsync(viewName, properties);
+            var task = provider.TrackPageViewAsync(viewName, properties, metrics);
             tasks.Add(task);
         }
 
@@ -97,13 +97,13 @@ public class Insights : IInsights
         return Task.CompletedTask;
     }
 
-    public Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null)
+    public Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 
         foreach (var provider in insightsProviders.Where(x => x.IsTrackEventsEnabled))
         {
-            var task = provider.TrackEventAsync(eventName, properties);
+            var task = provider.TrackEventAsync(eventName, properties, metrics);
             tasks.Add(task);
         }
 

--- a/TinyInsights/Insights.cs
+++ b/TinyInsights/Insights.cs
@@ -42,12 +42,12 @@ public class Insights : IInsights
         return insightsProviders;
     }
 
-    public Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public Task TrackErrorAsync(Exception ex, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         return TrackErrorAsync(ex, ErrorSeverity.Default, properties, metrics);
     }
 
-    public Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public Task TrackErrorAsync(Exception ex, ErrorSeverity severity, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 
@@ -69,7 +69,7 @@ public class Insights : IInsights
         return Task.CompletedTask;
     }
 
-    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public Task TrackPageViewAsync(string viewName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 
@@ -97,7 +97,7 @@ public class Insights : IInsights
         return Task.CompletedTask;
     }
 
-    public Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, IDictionary<string, double>? metrics = null)
+    public Task TrackEventAsync(string eventName, Dictionary<string, string>? properties = null, Dictionary<string, double>? metrics = null)
     {
         var tasks = new List<Task>();
 


### PR DESCRIPTION
Library was missing a way to log Application Insights metrics, added optional `Dictionary<string, double>` metrics parameters to `TrackErrorAsync()`, `TrackEventAsync()` and `TrackPageViewAsync()`. Also update the test project to show usage.