### PR TITLE
Fixed events per day #81

### DIFF
--- a/TinyInsights.Web/Services/InsightsService.Analytics.cs
+++ b/TinyInsights.Web/Services/InsightsService.Analytics.cs
@@ -32,7 +32,7 @@ public partial class InsightsService
     public Task<List<CountPerDay>> GetEventsPerDay(string eventName, GlobalFilter filter, CancellationToken cancellationToken = default)
     {
         var queryFilter = GetFilter(filter);
-        var query = $"customEvents | where{queryFilter} name == '{eventName}' | summarize count_sum = sum(itemCount) by bin(timestamp,1d)";
+        var query = $"customEvents | where{queryFilter} and name == '{eventName}' | summarize count_sum = sum(itemCount) by bin(timestamp,1d)";
 
         return GetPerDayResult(query, cancellationToken);
     }


### PR DESCRIPTION
This pull request makes a small but important fix to the event filtering logic in the `GetEventsPerDay` method. The change ensures that the event name filter is correctly combined with other conditions using `and`, which prevents incorrect query results.

* Fixed the query in `GetEventsPerDay` to use `and` when combining the event name with other filters, ensuring accurate event counting per day.